### PR TITLE
Implement column schema for trace sources

### DIFF
--- a/src/InstantTraceViewerUI/Etw/EtwTraceSource.EventDataHelpers.cs
+++ b/src/InstantTraceViewerUI/Etw/EtwTraceSource.EventDataHelpers.cs
@@ -18,8 +18,6 @@ namespace InstantTraceViewerUI.Etw
             newRecord.Level = ConvertLevel(data);
             newRecord.OpCode = (byte)data.Opcode;
             newRecord.Keywords = (ulong)data.Keywords;
-            newRecord.ActivityId = data.ActivityID;
-            newRecord.RelatedActivityId = data.RelatedActivityID;
 
             if (data.ProviderGuid == SystemProvider)
             {

--- a/src/InstantTraceViewerUI/Etw/EtwTraceSource.cs
+++ b/src/InstantTraceViewerUI/Etw/EtwTraceSource.cs
@@ -23,6 +23,21 @@ namespace InstantTraceViewerUI.Etw
 
     internal partial class EtwTraceSource : ITraceSource
     {
+        private static readonly TraceSourceSchemaColumn ColumnProcess = new TraceSourceSchemaColumn { Name = "Process", Type = TraceSourceSchemaColumnType.Int, DefaultColumnSize = 3.75f };
+        private static readonly TraceSourceSchemaColumn ColumnThread = new TraceSourceSchemaColumn { Name = "Thread", Type = TraceSourceSchemaColumnType.Int, DefaultColumnSize = 3.75f };
+        private static readonly TraceSourceSchemaColumn ColumnProvider = new TraceSourceSchemaColumn { Name = "Provider", Type = TraceSourceSchemaColumnType.Int, DefaultColumnSize = 6.25f };
+        private static readonly TraceSourceSchemaColumn ColumnOpCode = new TraceSourceSchemaColumn { Name = "OpCode", Type = TraceSourceSchemaColumnType.Int, DefaultColumnSize = 3.75f };
+        private static readonly TraceSourceSchemaColumn ColumnKeywords = new TraceSourceSchemaColumn { Name = "Keywords", Type = TraceSourceSchemaColumnType.Int, DefaultColumnSize = 3.75f };
+        private static readonly TraceSourceSchemaColumn ColumnName = new TraceSourceSchemaColumn { Name = "Name", Type = TraceSourceSchemaColumnType.Int, DefaultColumnSize = 8.75f };
+        private static readonly TraceSourceSchemaColumn ColumnLevel = new TraceSourceSchemaColumn { Name = "Level", Type = TraceSourceSchemaColumnType.Int, DefaultColumnSize = 3.75f };
+        private static readonly TraceSourceSchemaColumn ColumnTime = new TraceSourceSchemaColumn { Name = "Time", Type = TraceSourceSchemaColumnType.Int, DefaultColumnSize = 5.75f };
+        private static readonly TraceSourceSchemaColumn ColumnMessage = new TraceSourceSchemaColumn { Name = "Message", Type = TraceSourceSchemaColumnType.Int, DefaultColumnSize = null };
+
+        private static readonly TraceSourceSchema _schema = new TraceSourceSchema
+        {
+            Columns = [ColumnProcess, ColumnThread, ColumnProvider, ColumnOpCode, ColumnKeywords, ColumnName, ColumnLevel, ColumnTime, ColumnMessage]
+        };
+
         private static HashSet<int> SessionNums = new();
 
         // Fixed name is used because ETW sessions can outlive their processes and there is a low system limit. This way we replace leaked sessions rather than creating new ones.
@@ -167,80 +182,99 @@ namespace InstantTraceViewerUI.Etw
 
         public string DisplayName { get; private set; }
 
-        public string GetOpCodeName(byte opCode)
-        {
-            return
-                opCode == 0 ? string.Empty :
-                opCode == 10 ? "Load" :
-                opCode == 11 ? "Terminate" :
-                                ((TraceEventOpcode)opCode).ToString();
-        }
+        public TraceSourceSchema Schema => _schema;
 
-        public string GetKeywords(ulong keywords)
+        public string GetColumnString(TraceRecord traceRecord, TraceSourceSchemaColumn column, bool allowMultiline = false)
         {
-            StringBuilder sb = new();
-            void AppendString(string value)
+            if (column == ColumnProcess)
             {
-                if (sb.Length > 0)
-                {
-                    sb.Append(", ");
-                }
-                sb.Append(value);
+                return
+                    traceRecord.ProcessId == -1 ? string.Empty :
+                    _processNames.TryGetValue(traceRecord.ProcessId, out string name) && !string.IsNullOrEmpty(name) ? $"{traceRecord.ProcessId} ({name})" : traceRecord.ProcessId.ToString();
             }
-
-            void AppendKnownKeyword(KnownKeywords knownKeyword)
+            else if (column == ColumnThread)
             {
-                if ((keywords & (ulong)knownKeyword) == (ulong)knownKeyword)
-                {
-                    AppendString(knownKeyword.ToString());
-                    keywords &= ~(ulong)knownKeyword;
-                }
+                return
+                    traceRecord.ThreadId == -1 ? string.Empty :
+                    _threadNames.TryGetValue(traceRecord.ThreadId, out string name) ? $"{traceRecord.ThreadId} ({name})" : traceRecord.ThreadId.ToString();
             }
-
-            AppendKnownKeyword(KnownKeywords.TelemetryMeasures);
-            AppendKnownKeyword(KnownKeywords.TelemetryCritical);
-            AppendKnownKeyword(KnownKeywords.Telemetry);
-            if (keywords != 0)
+            else if (column == ColumnProvider)
             {
-                AppendString(keywords.ToString("X"));
+                return traceRecord.ProviderName;
             }
-
-            return sb.ToString();
-        }
-
-        public string GetProcessName(int processId)
-        {
-            return
-                processId == -1 ? string.Empty :
-                _processNames.TryGetValue(processId, out string name) && !string.IsNullOrEmpty(name) ? $"{processId} ({name})" : processId.ToString();
-        }
-
-        public string GetThreadName(int threadId)
-        {
-            return
-                threadId == -1 ? string.Empty :
-                _threadNames.TryGetValue(threadId, out string name) ? $"{threadId} ({name})" : threadId.ToString();
-        }
-
-        public string GetMessage(NamedValue[] namedValues, bool allowMultiline)
-        {
-            // TODO: In the future it would be nice to make these tooltips over the field which is underlined like a hyperlink.
-            TryGetCustomizedValue tryGetCustomizedValue = (string name, object value, out string customValue) =>
+            else if (column == ColumnLevel)
             {
-                string friendlyName;
-                if (value is int intValue && CodeLookup.TryGetFriendlyName(name, intValue, out friendlyName))
+                return traceRecord.Level.ToString();
+            }
+            else if (column == ColumnTime)
+            {
+                return traceRecord.Timestamp.ToString("HH:mm:ss.ffffff");
+            }
+            else if (column == ColumnOpCode)
+            {
+                return
+                    traceRecord.OpCode == 0 ? string.Empty :
+                    traceRecord.OpCode == 10 ? "Load" :
+                    traceRecord.OpCode == 11 ? "Terminate" : ((TraceEventOpcode)traceRecord.OpCode).ToString();
+            }
+            else if (column == ColumnKeywords)
+            {
+                StringBuilder sb = new();
+                void AppendString(string value)
                 {
-                    customValue = intValue == 0 ? 
-                        $"0 [{friendlyName}]" :
-                        $"0x{intValue:X8} [{friendlyName}]";
-                    return true;
+                    if (sb.Length > 0)
+                    {
+                        sb.Append(", ");
+                    }
+                    sb.Append(value);
                 }
 
-                customValue = null;
-                return false;
-            };
+                ulong keywords = traceRecord.Keywords;
+                void AppendKnownKeyword(KnownKeywords knownKeyword)
+                {
+                    if ((keywords & (ulong)knownKeyword) == (ulong)knownKeyword)
+                    {
+                        AppendString(knownKeyword.ToString());
+                        keywords &= ~(ulong)knownKeyword;
+                    }
+                }
 
-            return NamedValue.GetCollectionString(namedValues, allowMultiline, tryGetCustomizedValue);
+                AppendKnownKeyword(KnownKeywords.TelemetryMeasures);
+                AppendKnownKeyword(KnownKeywords.TelemetryCritical);
+                AppendKnownKeyword(KnownKeywords.Telemetry);
+                if (keywords != 0)
+                {
+                    AppendString(keywords.ToString("X"));
+                }
+
+                return sb.ToString();
+            }
+            else if (column == ColumnName)
+            {
+                return traceRecord.Name;
+            }
+            else if (column == ColumnMessage)
+            {
+                // TODO: In the future it would be nice to make these tooltips over the field which is underlined like a hyperlink.
+                TryGetCustomizedValue tryGetCustomizedValue = (string name, object value, out string customValue) =>
+                {
+                    string friendlyName;
+                    if (value is int intValue && CodeLookup.TryGetFriendlyName(name, intValue, out friendlyName))
+                    {
+                        customValue = intValue == 0 ?
+                            $"0 [{friendlyName}]" :
+                            $"0x{intValue:X8} [{friendlyName}]";
+                        return true;
+                    }
+
+                    customValue = null;
+                    return false;
+                };
+
+                return NamedValue.GetCollectionString(traceRecord.NamedValues, allowMultiline, tryGetCustomizedValue);
+            }
+
+            throw new NotImplementedException();
         }
 
         public bool CanClear => _etwSource.IsRealTime;

--- a/src/InstantTraceViewerUI/Etw/EtwTraceSource.cs
+++ b/src/InstantTraceViewerUI/Etw/EtwTraceSource.cs
@@ -16,22 +16,22 @@ namespace InstantTraceViewerUI.Etw
     [Flags]
     internal enum KnownKeywords : ulong
     {
-        Telemetry         = 0x0000200000000000,
+        Telemetry = 0x0000200000000000,
         TelemetryCritical = 0x0000800000000000,
         TelemetryMeasures = 0x0000400000000000,
     }
 
     internal partial class EtwTraceSource : ITraceSource
     {
-        private static readonly TraceSourceSchemaColumn ColumnProcess = new TraceSourceSchemaColumn { Name = "Process", Type = TraceSourceSchemaColumnType.Int, DefaultColumnSize = 3.75f };
-        private static readonly TraceSourceSchemaColumn ColumnThread = new TraceSourceSchemaColumn { Name = "Thread", Type = TraceSourceSchemaColumnType.Int, DefaultColumnSize = 3.75f };
-        private static readonly TraceSourceSchemaColumn ColumnProvider = new TraceSourceSchemaColumn { Name = "Provider", Type = TraceSourceSchemaColumnType.Int, DefaultColumnSize = 6.25f };
-        private static readonly TraceSourceSchemaColumn ColumnOpCode = new TraceSourceSchemaColumn { Name = "OpCode", Type = TraceSourceSchemaColumnType.Int, DefaultColumnSize = 3.75f };
-        private static readonly TraceSourceSchemaColumn ColumnKeywords = new TraceSourceSchemaColumn { Name = "Keywords", Type = TraceSourceSchemaColumnType.Int, DefaultColumnSize = 3.75f };
-        private static readonly TraceSourceSchemaColumn ColumnName = new TraceSourceSchemaColumn { Name = "Name", Type = TraceSourceSchemaColumnType.Int, DefaultColumnSize = 8.75f };
-        private static readonly TraceSourceSchemaColumn ColumnLevel = new TraceSourceSchemaColumn { Name = "Level", Type = TraceSourceSchemaColumnType.Int, DefaultColumnSize = 3.75f };
-        private static readonly TraceSourceSchemaColumn ColumnTime = new TraceSourceSchemaColumn { Name = "Time", Type = TraceSourceSchemaColumnType.Int, DefaultColumnSize = 5.75f };
-        private static readonly TraceSourceSchemaColumn ColumnMessage = new TraceSourceSchemaColumn { Name = "Message", Type = TraceSourceSchemaColumnType.Int, DefaultColumnSize = null };
+        private static readonly TraceSourceSchemaColumn ColumnProcess = new TraceSourceSchemaColumn { Name = "Process", DefaultColumnSize = 3.75f };
+        private static readonly TraceSourceSchemaColumn ColumnThread = new TraceSourceSchemaColumn { Name = "Thread", DefaultColumnSize = 3.75f };
+        private static readonly TraceSourceSchemaColumn ColumnProvider = new TraceSourceSchemaColumn { Name = "Provider", DefaultColumnSize = 6.25f };
+        private static readonly TraceSourceSchemaColumn ColumnOpCode = new TraceSourceSchemaColumn { Name = "OpCode", DefaultColumnSize = 3.75f };
+        private static readonly TraceSourceSchemaColumn ColumnKeywords = new TraceSourceSchemaColumn { Name = "Keywords", DefaultColumnSize = 3.75f };
+        private static readonly TraceSourceSchemaColumn ColumnName = new TraceSourceSchemaColumn { Name = "Name", DefaultColumnSize = 8.75f };
+        private static readonly TraceSourceSchemaColumn ColumnLevel = new TraceSourceSchemaColumn { Name = "Level", DefaultColumnSize = 3.75f };
+        private static readonly TraceSourceSchemaColumn ColumnTime = new TraceSourceSchemaColumn { Name = "Time", DefaultColumnSize = 5.75f };
+        private static readonly TraceSourceSchemaColumn ColumnMessage = new TraceSourceSchemaColumn { Name = "Message", DefaultColumnSize = null };
 
         private static readonly TraceSourceSchema _schema = new TraceSourceSchema
         {

--- a/src/InstantTraceViewerUI/ITraceSource.cs
+++ b/src/InstantTraceViewerUI/ITraceSource.cs
@@ -4,7 +4,7 @@ using InstantTraceViewer;
 
 namespace InstantTraceViewerUI
 {
-    internal enum TraceLevel
+    public enum TraceLevel
     {
         Always,
         Critical,
@@ -14,7 +14,7 @@ namespace InstantTraceViewerUI
         Verbose,
     }
 
-    internal struct TraceRecord
+    public struct TraceRecord
     {
         public int ProcessId;
 
@@ -30,17 +30,12 @@ namespace InstantTraceViewerUI
 
         public byte OpCode;
 
-        // 0 = None, ...., -1L = All
         public ulong Keywords;
 
         public DateTime Timestamp;
-
-        public Guid ActivityId;
-
-        public Guid RelatedActivityId;
     }
 
-    struct TraceRecordSnapshot
+    public struct TraceRecordSnapshot
     {
         public TraceRecordSnapshot()
         {
@@ -49,27 +44,65 @@ namespace InstantTraceViewerUI
         }
 
         public IReadOnlyList<TraceRecord> Records;
+
+        /// <summary>
+        /// This will increment if existing records have been modified or removed.
+        /// This does not increase if new records are added, so it should be a rare event.
+        /// </summary>
         public int GenerationId;
     }
 
-    internal interface ITraceSource : IDisposable
+    public interface ITraceSource : IDisposable
     {
         string DisplayName { get; }
 
-        string GetOpCodeName(byte opCode);
+        TraceSourceSchema Schema { get; }
 
-        string GetKeywords(ulong keywords);
-
-        string GetProcessName(int processId);
-
-        string GetThreadName(int threadId);
-
-        string GetMessage(NamedValue[] namedValues, bool allowMultiline = false);
+        string GetColumnString(TraceRecord traceRecord, TraceSourceSchemaColumn column, bool allowMultiline = false);
+        //DateTime GetColumnDateTime(TraceRecord traceRecord, TraceSourceSchemaColumn column);
+        //int GetColumnInt(TraceRecord traceRecord, TraceSourceSchemaColumn column); 
+        //NamedValue[] GetNamedValues(TraceRecord traceRecord, TraceSourceSchemaColumn column);
 
         bool CanClear { get; }
 
         void Clear();
 
         TraceRecordSnapshot CreateSnapshot();
+    }
+
+    [Flags]
+    public enum TraceSourceSchemaColumnType
+    {
+        String = 0x01,
+        Int = 0x02,
+        DateTime = 0x04,
+        NamedValues = 0x08,
+        // TODO: Trace level?
+        // TODO: UInt, Long, ULong, Float, Double, Guid.
+
+        // Special flags that can be combined with the above
+        ProcessId = 0x100,
+        ThreadId = 0x200,
+        Timestamp = 0x400,
+        EventName = 0x800,
+        Message = 0x1000
+    }
+
+    public class TraceSourceSchemaColumn
+    {
+        public string Name { get; init;  }
+
+        public TraceSourceSchemaColumnType Type { get; init; }
+
+        /// <summary>
+        /// Size is multipled by the current font height in pixels.
+        /// Returns null when the column size is stretched (this is only recommended for the message).
+        /// </summary>
+        public float? DefaultColumnSize { get; init; }
+    }
+
+    public class TraceSourceSchema
+    {
+        public IReadOnlyList<TraceSourceSchemaColumn> Columns { get; init; }
     }
 }

--- a/src/InstantTraceViewerUI/ITraceSource.cs
+++ b/src/InstantTraceViewerUI/ITraceSource.cs
@@ -70,29 +70,9 @@ namespace InstantTraceViewerUI
         TraceRecordSnapshot CreateSnapshot();
     }
 
-    [Flags]
-    public enum TraceSourceSchemaColumnType
-    {
-        String = 0x01,
-        Int = 0x02,
-        DateTime = 0x04,
-        NamedValues = 0x08,
-        // TODO: Trace level?
-        // TODO: UInt, Long, ULong, Float, Double, Guid.
-
-        // Special flags that can be combined with the above
-        ProcessId = 0x100,
-        ThreadId = 0x200,
-        Timestamp = 0x400,
-        EventName = 0x800,
-        Message = 0x1000
-    }
-
     public class TraceSourceSchemaColumn
     {
         public string Name { get; init;  }
-
-        public TraceSourceSchemaColumnType Type { get; init; }
 
         /// <summary>
         /// Size is multipled by the current font height in pixels.

--- a/src/InstantTraceViewerUI/ITraceSource.cs
+++ b/src/InstantTraceViewerUI/ITraceSource.cs
@@ -59,9 +59,6 @@ namespace InstantTraceViewerUI
         TraceSourceSchema Schema { get; }
 
         string GetColumnString(TraceRecord traceRecord, TraceSourceSchemaColumn column, bool allowMultiline = false);
-        //DateTime GetColumnDateTime(TraceRecord traceRecord, TraceSourceSchemaColumn column);
-        //int GetColumnInt(TraceRecord traceRecord, TraceSourceSchemaColumn column); 
-        //NamedValue[] GetNamedValues(TraceRecord traceRecord, TraceSourceSchemaColumn column);
 
         bool CanClear { get; }
 

--- a/src/InstantTraceViewerUI/LogViewerWindow/LogViewerWindow.cs
+++ b/src/InstantTraceViewerUI/LogViewerWindow/LogViewerWindow.cs
@@ -605,13 +605,13 @@ namespace InstantTraceViewerUI
                 {
                     string displayText = _traceSource.TraceSource.GetColumnString(traceRecord, column, allowMultiline: false);
                     if (displayText.Contains(text, StringComparison.InvariantCultureIgnoreCase))
-                {
-                    setScrollIndex = visibleRowIndex;
-                    _lastSelectedVisibleRowIndex = visibleRowIndex;
-                    _selectedTraceRecordIds.Clear();
-                    _selectedTraceRecordIds.Add(visibleTraceRecords.GetRecordId(visibleRowIndex));
-                    break;
-}
+                    {
+                        setScrollIndex = visibleRowIndex;
+                        _lastSelectedVisibleRowIndex = visibleRowIndex;
+                        _selectedTraceRecordIds.Clear();
+                        _selectedTraceRecordIds.Add(visibleTraceRecords.GetRecordId(visibleRowIndex));
+                        break;
+                    }
                 }
 
                 visibleRowIndex = (_findFoward ? visibleRowIndex + 1 : visibleRowIndex - 1);

--- a/src/InstantTraceViewerUI/Logcat/LogcatTraceSource.cs
+++ b/src/InstantTraceViewerUI/Logcat/LogcatTraceSource.cs
@@ -13,12 +13,12 @@ namespace InstantTraceViewerUI
 {
     internal class LogcatTraceSource : ITraceSource
     {
-        private static readonly TraceSourceSchemaColumn ColumnProcess = new TraceSourceSchemaColumn { Name = "Process", Type = TraceSourceSchemaColumnType.Int, DefaultColumnSize = 3.75f };
-        private static readonly TraceSourceSchemaColumn ColumnThread = new TraceSourceSchemaColumn { Name = "Thread", Type = TraceSourceSchemaColumnType.Int, DefaultColumnSize = 3.75f };
-        private static readonly TraceSourceSchemaColumn ColumnTag = new TraceSourceSchemaColumn { Name = "Tag", Type = TraceSourceSchemaColumnType.Int, DefaultColumnSize = 8.75f };
-        private static readonly TraceSourceSchemaColumn ColumnPriority = new TraceSourceSchemaColumn { Name = "Priority", Type = TraceSourceSchemaColumnType.Int, DefaultColumnSize = 3.75f };
-        private static readonly TraceSourceSchemaColumn ColumnTime = new TraceSourceSchemaColumn { Name = "Time", Type = TraceSourceSchemaColumnType.Int, DefaultColumnSize = 5.75f };
-        private static readonly TraceSourceSchemaColumn ColumnMessage = new TraceSourceSchemaColumn { Name = "Message", Type = TraceSourceSchemaColumnType.Int, DefaultColumnSize = null };
+        private static readonly TraceSourceSchemaColumn ColumnProcess = new TraceSourceSchemaColumn { Name = "Process", DefaultColumnSize = 3.75f };
+        private static readonly TraceSourceSchemaColumn ColumnThread = new TraceSourceSchemaColumn { Name = "Thread", DefaultColumnSize = 3.75f };
+        private static readonly TraceSourceSchemaColumn ColumnTag = new TraceSourceSchemaColumn { Name = "Tag", DefaultColumnSize = 8.75f };
+        private static readonly TraceSourceSchemaColumn ColumnPriority = new TraceSourceSchemaColumn { Name = "Priority", DefaultColumnSize = 3.75f };
+        private static readonly TraceSourceSchemaColumn ColumnTime = new TraceSourceSchemaColumn { Name = "Time", DefaultColumnSize = 5.75f };
+        private static readonly TraceSourceSchemaColumn ColumnMessage = new TraceSourceSchemaColumn { Name = "Message", DefaultColumnSize = null };
 
         private static readonly TraceSourceSchema _schema = new TraceSourceSchema
         {


### PR DESCRIPTION
This moves from a fixed table schema to a flexible schema that each trace source can define.

More work will follow this change to convert TraceRecord from a structure to an opaque atom/id/handle.