### PR TITLE
Escaped quote csv parser fix

### DIFF
--- a/src/Common/TextParsers/CsvTableSource.cs
+++ b/src/Common/TextParsers/CsvTableSource.cs
@@ -41,14 +41,13 @@ namespace InstantTraceViewer
                         ch = textReader.Read();
                         if (ch == '\"' || ch == -1)
                         {
-                            if (textReader.Peek() == '\"')
+                            if (textReader.Peek() != '\"')
                             {
-                                // This is an escaped quote.
-                                valueBuilder.Append('\"');
-                                continue;
+                                break;
                             }
 
-                            break;
+                            // This is an escaped quote.
+                            ch = textReader.Read();
                         }
 
                         valueBuilder.Append((char)ch);

--- a/src/UnitTests/CsvParserTests.cs
+++ b/src/UnitTests/CsvParserTests.cs
@@ -94,11 +94,11 @@ namespace InstantTraceViewerTests
         [TestMethod]
         public void TestQuotesEscaped()
         {
-            ITraceTableSnapshot emptyNoHeader = ReadTestString("a,\"b,\"\"c\"\"\",d", false).CreateSnapshot();
+            ITraceTableSnapshot emptyNoHeader = ReadTestString("a,\"b,\"\",c\"\"\",d", false).CreateSnapshot();
             Assert.AreEqual(3, emptyNoHeader.Schema.Columns.Count);
             Assert.AreEqual(1, emptyNoHeader.RowCount);
             Assert.AreEqual("a", emptyNoHeader.GetColumnString(0, emptyNoHeader.Schema.Columns[0]));
-            Assert.AreEqual("b,\"c\"", emptyNoHeader.GetColumnString(0, emptyNoHeader.Schema.Columns[1]));
+            Assert.AreEqual("b,\",c\"", emptyNoHeader.GetColumnString(0, emptyNoHeader.Schema.Columns[1]));
             Assert.AreEqual("d", emptyNoHeader.GetColumnString(0, emptyNoHeader.Schema.Columns[2]));
         }
 


### PR DESCRIPTION
Parser did not "eat" the second quote. This could cause it to do the wrong thing.