### PR TITLE
Improved handling of non-.ETL file extensions

### DIFF
--- a/src/InstantTraceViewerUI/Etw/EtwTraceSource.cs
+++ b/src/InstantTraceViewerUI/Etw/EtwTraceSource.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using InstantTraceViewer;
 
@@ -87,6 +88,9 @@ namespace InstantTraceViewerUI.Etw
             _processingThread = new Thread(() => ProcessThread());
             _processingThread.Start();
         }
+
+        // Autologgers save the etl extensions with a number suffix. Associate a handful of them too.
+        public static IEnumerable<string> EtlFileExtensions => new[] { ".etl" }.Concat(Enumerable.Range(1, 15).Select(i => $".{i:D3}"));
 
         private void AddEvent(EtwRecord record)
         {

--- a/src/InstantTraceViewerUI/InstantTraceViewerUI.csproj
+++ b/src/InstantTraceViewerUI/InstantTraceViewerUI.csproj
@@ -53,7 +53,7 @@
 
   <ItemGroup>
     <PackageReference Include="AdvancedSharpAdbClient" Version="3.3.13" />
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.16" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.18" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>

--- a/src/InstantTraceViewerUI/MainWindow.cs
+++ b/src/InstantTraceViewerUI/MainWindow.cs
@@ -8,6 +8,7 @@ using AdvancedSharpAdbClient;
 using AdvancedSharpAdbClient.Models;
 using ImGuiNET;
 using InstantTraceViewer;
+using InstantTraceViewerUI.Etw;
 
 namespace InstantTraceViewerUI
 {
@@ -32,8 +33,7 @@ namespace InstantTraceViewerUI
         {
             if (args.Length == 1 && Path.Exists(args[0]))
             {
-                var etlExts = new[] { ".etl" }.Concat(Enumerable.Range(1, 15).Select(i => $".{i:D3}")).ToHashSet(StringComparer.OrdinalIgnoreCase);
-                if (etlExts.Contains(Path.GetExtension(args[0])))
+                if (EtwTraceSource.EtlFileExtensions.Contains(Path.GetExtension(args[0]), StringComparer.OrdinalIgnoreCase))
                 {
                     var etlSession = Etw.EtwTraceSource.CreateEtlSession(args[0]);
                     _logViewerWindows.Add(new LogViewerWindow(etlSession));
@@ -213,8 +213,10 @@ namespace InstantTraceViewerUI
 
                     if (ImGui.MenuItem("Open ETL file..."))
                     {
+                        string joinedExts = string.Join(';', EtwTraceSource.EtlFileExtensions.Select(ext => $"*{ext}"));
+
                         // TODO: This blocks the render thread
-                        string file = OpenFile("ETL Trace Files (*.etl)|*.etl",
+                        string file = OpenFile($"ETL Trace Files ({joinedExts})|{joinedExts}",
                             Settings.EtlOpenLocation,
                             (s) => Settings.EtlOpenLocation = s);
                         if (!string.IsNullOrEmpty(file))

--- a/src/InstantTraceViewerUI/Settings.cs
+++ b/src/InstantTraceViewerUI/Settings.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Win32;
+﻿using InstantTraceViewerUI.Etw;
+using Microsoft.Win32;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -154,16 +155,11 @@ namespace InstantTraceViewerUI
             openKey.SetValue("Icon", $"\"{exePath}\"");
             commandKey.SetValue("", $"\"{exePath}\" \"%1\"");
 
-            using var openWithKey = Registry.CurrentUser.CreateSubKey(@"Software\Classes\.etl\OpenWithProgids");
-            openWithKey.SetValue("", "InstantTraceViewerUI.etl");
-            openWithKey.SetValue("InstantTraceViewerUI.etl", "");
-
-            // Autologgers save the etl extensions with a number suffix. Associate a handful of them
-            for (int i = 1; i <= 15; i++)
+            foreach (string ext in EtwTraceSource.EtlFileExtensions)
             {
-                using var extKey = Registry.CurrentUser.CreateSubKey($@"Software\Classes\.{i:D3}\OpenWithProgids");
-                extKey.SetValue("", "InstantTraceViewerUI.etl");
-                extKey.SetValue("InstantTraceViewerUI.etl", "");
+                using var openWithKey = Registry.CurrentUser.CreateSubKey(@"Software\Classes\.etl\OpenWithProgids");
+                openWithKey.SetValue("", "InstantTraceViewerUI.etl");
+                openWithKey.SetValue("InstantTraceViewerUI.etl", "");
             }
         }
     }


### PR DESCRIPTION
Autologger files (e.g. *.001) weren't showing in the ETL open file dialog.