### PR TITLE
Improve ID for better persistence

### DIFF
--- a/src/Common/MinUniqueId.cs
+++ b/src/Common/MinUniqueId.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace InstantTraceViewerUI
+{
+    // ImGui uses IDs to uniquely identify windows and widget, so we must generate unique IDs for each active window and widget.
+    // HOWEVER, these unique IDs are also used for persisted settings. So these IDs must be unique across multiple active windows,
+    // but we also want to "collide" them across runs when possible to maintain any saved settings across runs.
+    // The current solution is to prefer a smallest number that isn't currently in use. The more concurrent windows that are open,
+    // the more likely the user will get a "default" layout because there will be no persisted settings available.
+    public class MinUniqueId
+    {
+        private static int _nextId = 1;
+        private static readonly SortedSet<int> _returnedIds = new();
+
+        public int TakeId()
+        {
+            int smallestReturnedId = _returnedIds.FirstOrDefault(-1);
+            if (smallestReturnedId != -1)
+            {
+                _returnedIds.Remove(smallestReturnedId);
+                return smallestReturnedId;
+            }
+
+            return _nextId++;
+        }
+
+        public void ReturnId(int id)
+        {
+            _returnedIds.Add(id);
+        }
+    }
+}

--- a/src/InstantTraceViewerUI/LogViewerWindow/FiltersEditorWindow.cs
+++ b/src/InstantTraceViewerUI/LogViewerWindow/FiltersEditorWindow.cs
@@ -14,7 +14,7 @@ namespace InstantTraceViewerUI
         private const string WindowName = "Filters Editor";
 
         private readonly string _name;
-        private readonly Guid _windowId;
+        private readonly string _parentWindowId;
 
         private TraceTableRowSelectorSyntax? _parser;
         private TraceTableSchema? _parserTableSchema;
@@ -28,10 +28,10 @@ namespace InstantTraceViewerUI
 
         private bool _open = true;
 
-        public FiltersEditorWindow(string name, Guid windowId)
+        public FiltersEditorWindow(string name, string parentWindowId)
         {
             _name = name;
-            _windowId = windowId;
+            _parentWindowId = parentWindowId;
         }
 
         public unsafe bool DrawWindow(IUiCommands uiCommands, ViewerRules rules, TraceTableSchema tableSchema)
@@ -39,7 +39,7 @@ namespace InstantTraceViewerUI
             ImGui.SetNextWindowSize(new Vector2(800, 400), ImGuiCond.FirstUseEver);
             ImGui.SetNextWindowSizeConstraints(new Vector2(400, 150), new Vector2(float.MaxValue, float.MaxValue));
 
-            if (ImGui.Begin($"{WindowName} - {_name}###FiltersEditor_{_windowId}", ref _open))
+            if (ImGui.Begin($"{WindowName} - {_name}###FiltersEditor_{_parentWindowId}", ref _open))
             {
                 if (_parserTableSchema != tableSchema)
                 {

--- a/src/InstantTraceViewerUI/LogViewerWindow/SpamFilter/CountByEventName.cs
+++ b/src/InstantTraceViewerUI/LogViewerWindow/SpamFilter/CountByEventName.cs
@@ -19,9 +19,9 @@ namespace InstantTraceViewerUI
 
             public override void AddColumnValues()
             {
-                ImGui.TextUnformatted(ProviderName);
-                ImGui.TableNextColumn();
                 ImGui.TextUnformatted(Name);
+                ImGui.TableNextColumn();
+                ImGui.TextUnformatted(ProviderName);
                 ImGui.TableNextColumn();
                 ImGui.TextUnformatted(MaxLevel?.ToString() ?? "");
             }
@@ -37,15 +37,15 @@ namespace InstantTraceViewerUI
             _schema = schema;
         }
 
-        public override string Name => $"{ProviderColumnName}, {NameColumnName}";
+        public override string Name => $"{NameColumnName}, {ProviderColumnName}";
 
         public override int ColumnCount => 3;
 
         public override void SetupColumns()
         {
             ImGuiTableColumnFlags DefaultHideIfColumnNull(TraceSourceSchemaColumn column) => column == null ? ImGuiTableColumnFlags.DefaultHide : 0;
-            ImGui.TableSetupColumn(ProviderColumnName, ImGuiTableColumnFlags.WidthStretch | DefaultHideIfColumnNull(_schema.ProviderColumn), 1);
             ImGui.TableSetupColumn(NameColumnName, ImGuiTableColumnFlags.WidthStretch, 1);
+            ImGui.TableSetupColumn(ProviderColumnName, ImGuiTableColumnFlags.WidthStretch | DefaultHideIfColumnNull(_schema.ProviderColumn), 1);
             ImGui.TableSetupColumn(LevelColumnName, ImGuiTableColumnFlags.WidthFixed | DefaultHideIfColumnNull(_schema.UnifiedLevelColumn), 8 * ImGui.GetFontSize());
         }
 
@@ -76,8 +76,8 @@ namespace InstantTraceViewerUI
         public override IEnumerable<CountByBase> ImGuiSort(ImGuiTableColumnSortSpecsPtr spec, IEnumerable<CountByBase> list)
             => spec.ColumnIndex switch
             {
-                0 => ImGuiSortInternal(spec.SortDirection, list, p => ((CountByEventName)p).ProviderName),
-                1 => ImGuiSortInternal(spec.SortDirection, list, p => ((CountByEventName)p).Name),
+                0 => ImGuiSortInternal(spec.SortDirection, list, p => ((CountByEventName)p).Name),
+                1 => ImGuiSortInternal(spec.SortDirection, list, p => ((CountByEventName)p).ProviderName),
                 2 => ImGuiSortInternal(spec.SortDirection, list, p => ((CountByEventName)p).MaxLevel),
                 3 => ImGuiSortInternal(spec.SortDirection, list, p => ((CountByEventName)p).Count),
                 _ => throw new ArgumentOutOfRangeException(nameof(spec), "Unknown column index")

--- a/src/InstantTraceViewerUI/LogViewerWindow/SpamFilter/SpamFilterWindow.cs
+++ b/src/InstantTraceViewerUI/LogViewerWindow/SpamFilter/SpamFilterWindow.cs
@@ -12,7 +12,7 @@ namespace InstantTraceViewerUI
         private const string WindowName = "Spam Filter";
 
         private readonly string _name;
-        private readonly Guid _windowId;
+        private readonly string _parentWindowId;
 
 
         private IReadOnlyList<CountByBaseAdapter> _adapters;
@@ -24,10 +24,10 @@ namespace InstantTraceViewerUI
 
         private bool _open = true;
 
-        public SpamFilterWindow(string name, Guid windowId)
+        public SpamFilterWindow(string name, string parentWindowId)
         {
             _name = name;
-            _windowId = windowId;
+            _parentWindowId = parentWindowId;
         }
 
         public unsafe bool DrawWindow(IUiCommands uiCommands, ViewerRules viewerRules, ITraceTableSnapshot traceTable)
@@ -43,7 +43,7 @@ namespace InstantTraceViewerUI
             ImGui.SetNextWindowSize(new Vector2(800, 400), ImGuiCond.FirstUseEver);
             ImGui.SetNextWindowSizeConstraints(new Vector2(400, 150), new Vector2(float.MaxValue, float.MaxValue));
 
-            if (ImGui.Begin($"{WindowName} - {_name}###SpamFilter_{_windowId}", ref _open))
+            if (ImGui.Begin($"{WindowName} - {_name}###SpamFilter_{_parentWindowId}", ref _open))
             {
                 ImGui.SetNextItemWidth(15 * ImGui.GetFontSize());
                 if (ImGui.BeginCombo("Count by group", _currentAdapter.Name))

--- a/src/InstantTraceViewerUI/LogViewerWindow/TimelineWindow.cs
+++ b/src/InstantTraceViewerUI/LogViewerWindow/TimelineWindow.cs
@@ -15,7 +15,7 @@ namespace InstantTraceViewerUI
         private const string PopupName = "Timeline";
 
         private readonly string _name;
-        private readonly Guid _windowId;
+        private readonly string _parentWindowId;
 
         private bool _open = true;
 
@@ -31,10 +31,10 @@ namespace InstantTraceViewerUI
         private ComputedTimeline _computedTimeline;
         private Task<ComputedTimeline> _nextComputedTimelineTask;
 
-        public TimelineWindow(string name, Guid windowId)
+        public TimelineWindow(string name, string parentWindowId)
         {
             _name = name;
-            _windowId = windowId;
+            _parentWindowId = parentWindowId;
         }
 
         public bool DrawWindow(IUiCommands uiCommands, ITraceTableSnapshot traceTable, DateTime? startWindow, DateTime? endWindow)
@@ -42,7 +42,7 @@ namespace InstantTraceViewerUI
             ImGui.SetNextWindowSize(new Vector2(1000, 70), ImGuiCond.FirstUseEver);
             ImGui.SetNextWindowSizeConstraints(new Vector2(100, 70), new Vector2(float.MaxValue, float.MaxValue));
 
-            if (ImGui.Begin($"{PopupName} - {_name}###Timeline_{_windowId}", ref _open))
+            if (ImGui.Begin($"{PopupName} - {_name}###Timeline_{_parentWindowId}", ref _open))
             {
                 DrawTimelineGraph(traceTable, startWindow, endWindow);
             }


### PR DESCRIPTION
Previously GUIDs were used for each window which ensured uniqueness, but made every window look new even across runs. Instead a "minimum unique integer" is used so that they are unique across active windows, but bias towards re-use across runs so persistence of layout (column reorder, size, etc) is likely.