### PR TITLE
Fix wrong process/thread names shown for some traces

### DIFF
--- a/src/InstantTraceViewerUI/Etw/EtwRecord.cs
+++ b/src/InstantTraceViewerUI/Etw/EtwRecord.cs
@@ -10,6 +10,10 @@ namespace InstantTraceViewerUI.Etw
 
         public int ThreadId;
 
+        public string ProcessName;
+
+        public string ThreadName;
+
         public TraceEventLevel Level;
 
         public string ProviderName;

--- a/src/InstantTraceViewerUI/Etw/EtwTraceSource.DynamicEventHandler.cs
+++ b/src/InstantTraceViewerUI/Etw/EtwTraceSource.DynamicEventHandler.cs
@@ -23,24 +23,7 @@ namespace InstantTraceViewerUI.Etw
 
             for (int i = 0; i < data.PayloadNames.Length; i++)
             {
-                // Extract process and thread IDs from events without them (e.g. Kernel events).
-                if (string.Equals(data.PayloadNames[i], "ProcessID", StringComparison.OrdinalIgnoreCase) && data.PayloadValue(i) is int pid)
-                {
-                    if (newRecord.ProcessId == -1)
-                    {
-                        newRecord.ProcessId = pid;
-                    }
-                    continue;
-                }
-                else if (string.Equals(data.PayloadNames[i], "ThreadID", StringComparison.OrdinalIgnoreCase) && data.PayloadValue(i) is int tid)
-                {
-                    if (newRecord.ThreadId == -1)
-                    {
-                        newRecord.ThreadId = tid;
-                    }
-                    continue;
-                }
-                else if (data.PayloadNames[i] == "PartA_PrivTags" && data.PayloadValue(i) is long)
+                if (data.PayloadNames[i] == "PartA_PrivTags" && data.PayloadValue(i) is long)
                 {
                     // Put the priv tag last since it's mostly noise.
                     privTag = (long)data.PayloadValue(i);

--- a/src/InstantTraceViewerUI/Etw/EtwTraceSource.EventDataHelpers.cs
+++ b/src/InstantTraceViewerUI/Etw/EtwTraceSource.EventDataHelpers.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Diagnostics.Tracing;
+﻿using InstantTraceViewer;
+using Microsoft.Diagnostics.Tracing;
 using System;
 using System.Text;
 
@@ -9,7 +10,7 @@ namespace InstantTraceViewerUI.Etw
         // The ETW parser calls the kernel event provider "MSNT_SystemTrace" but we rename to Kernel for simplicity.
         private readonly static Guid SystemProvider = Guid.Parse("{9e814aad-3204-11d2-9a82-006008a86939}");
 
-        private static EtwRecord CreateBaseTraceRecord(TraceEvent data)
+        private EtwRecord CreateBaseTraceRecord(TraceEvent data)
         {
             var newRecord = new EtwRecord();
             newRecord.ProcessId = data.ProcessID;
@@ -18,6 +19,25 @@ namespace InstantTraceViewerUI.Etw
             newRecord.Level = data.Level;
             newRecord.OpCode = (byte)data.Opcode;
             newRecord.Keywords = (ulong)data.Keywords;
+
+            // Extract process and thread IDs from events without them (e.g. some Kernel events).
+            if (newRecord.ProcessId == -1 || newRecord.ThreadId == -1)
+            {
+                for (int i = 0; i < data.PayloadNames.Length; i++)
+                {
+                    if (newRecord.ProcessId == -1 && string.Equals(data.PayloadNames[i], "ProcessID", StringComparison.OrdinalIgnoreCase) && data.PayloadValue(i) is int pid)
+                    {
+                        newRecord.ProcessId = pid;
+                    }
+                    else if (newRecord.ThreadId == -1 && string.Equals(data.PayloadNames[i], "ThreadID", StringComparison.OrdinalIgnoreCase) && data.PayloadValue(i) is int tid)
+                    {
+                        newRecord.ThreadId = tid;
+                    }
+                }
+            }
+
+            newRecord.ProcessName = _processNames.TryGetValue(newRecord.ProcessId, out string processName) ? processName : null;
+            newRecord.ThreadName = _threadNames.TryGetValue(newRecord.ThreadId, out string threadName) ? threadName : null;
 
             if (data.ProviderGuid == SystemProvider)
             {

--- a/src/InstantTraceViewerUI/Etw/EtwTraceSource.cs
+++ b/src/InstantTraceViewerUI/Etw/EtwTraceSource.cs
@@ -237,8 +237,6 @@ namespace InstantTraceViewerUI.Etw
 
                 return new EtwTraceTableSnapshot
                 {
-                    ProcessNames = _processNames,
-                    ThreadNames = _threadNames,
                     RecordSnapshot = _traceRecords.CreateSnapshot(),
                     GenerationId = _generationId,
                     Schema = _schema,
@@ -267,6 +265,7 @@ namespace InstantTraceViewerUI.Etw
                     {
                         // We could go lower-level if it is useful and PInvoke QueryFullProcessImageName and open the process handle with PROCESS_QUERY_LIMITED_INFORMATION,
                         // but since this is a realtime session, we're probably elevated already and shouldn't have problems. This would also avoid the need for a try-catch.
+                        // However we now have no way to know if the process terminated and the process id could be re-used in the future.
                         using (var process = Process.GetProcessById(record.ProcessId))
                         {
                             return process.ProcessName;

--- a/src/InstantTraceViewerUI/Etw/EtwTraceTableSnapshot.cs
+++ b/src/InstantTraceViewerUI/Etw/EtwTraceTableSnapshot.cs
@@ -8,8 +8,6 @@ namespace InstantTraceViewerUI.Etw
 {
     class EtwTraceTableSnapshot : ITraceTableSnapshot
     {
-        public IReadOnlyDictionary<int, string> ThreadNames { get; init; }
-        public IReadOnlyDictionary<int, string> ProcessNames { get; init; }
         public ListBuilderSnapshot<EtwRecord> RecordSnapshot { get; init; }
 
         public TraceTableSchema Schema { get; init; }
@@ -26,13 +24,13 @@ namespace InstantTraceViewerUI.Etw
             {
                 return
                     traceRecord.ProcessId == -1 ? string.Empty :
-                    ProcessNames.TryGetValue(traceRecord.ProcessId, out string name) && !string.IsNullOrEmpty(name) ? $"{traceRecord.ProcessId} ({name})" : traceRecord.ProcessId.ToString();
+                    !string.IsNullOrEmpty(traceRecord.ProcessName) ? $"{traceRecord.ProcessId} ({traceRecord.ProcessName})" : traceRecord.ProcessId.ToString();
             }
             else if (column == EtwTraceSource.ColumnThread)
             {
                 return
                     traceRecord.ThreadId == -1 ? string.Empty :
-                    ThreadNames.TryGetValue(traceRecord.ThreadId, out string name) ? $"{traceRecord.ThreadId} ({name})" : traceRecord.ThreadId.ToString();
+                    !string.IsNullOrEmpty(traceRecord.ThreadName) ? $"{traceRecord.ThreadId} ({traceRecord.ThreadName})" : traceRecord.ThreadId.ToString();
             }
             else if (column == EtwTraceSource.ColumnProvider)
             {
@@ -117,8 +115,8 @@ namespace InstantTraceViewerUI.Etw
         }
 
         public string GetColumnValueNameForId(int rowIndex, TraceSourceSchemaColumn column)
-            => column == EtwTraceSource.ColumnProcess ? (ProcessNames.TryGetValue(RecordSnapshot[rowIndex].ProcessId, out string processName) ? processName : null) :
-               column == EtwTraceSource.ColumnThread ? (ThreadNames.TryGetValue(RecordSnapshot[rowIndex].ThreadId, out string threadName) ? threadName : null) :
+            => column == EtwTraceSource.ColumnProcess ? RecordSnapshot[rowIndex].ProcessName :
+               column == EtwTraceSource.ColumnThread ? RecordSnapshot[rowIndex].ThreadName :
                throw new NotSupportedException();
 
         public int GetColumnValueInt(int rowIndex, TraceSourceSchemaColumn column)

--- a/src/InstantTraceViewerUI/Logcat/LogcatRecord.cs
+++ b/src/InstantTraceViewerUI/Logcat/LogcatRecord.cs
@@ -7,6 +7,8 @@ namespace InstantTraceViewerUI.Logcat
     {
         public int ProcessId;
 
+        public string ProcessName;
+
         public int ThreadId;
 
         public Priority Priority;

--- a/src/InstantTraceViewerUI/Logcat/LogcatTraceSource.cs
+++ b/src/InstantTraceViewerUI/Logcat/LogcatTraceSource.cs
@@ -1,4 +1,4 @@
-﻿using AdvancedSharpAdbClient;
+using AdvancedSharpAdbClient;
 using AdvancedSharpAdbClient.DeviceCommands;
 using AdvancedSharpAdbClient.Logs;
 using AdvancedSharpAdbClient.Models;
@@ -95,7 +95,6 @@ namespace InstantTraceViewerUI.Logcat
             {
                 return new LogcatTraceTableSnapshot
                 {
-                    ProcessNames = _processNames,
                     RecordSnapshot = _traceRecords.CreateSnapshot(),
                     GenerationId = _generationId,
                     Schema = _schema,
@@ -124,10 +123,12 @@ namespace InstantTraceViewerUI.Logcat
                     {
                         ProcessSystemMessage(androidLogEntry);
 
+                        _processNames.TryGetValue(androidLogEntry.ProcessId, out string processName);
                         var preciseTimestamp = androidLogEntry.TimeStamp.ToLocalTime() + TimeSpan.FromTicks(androidLogEntry.NanoSeconds / TimeSpan.NanosecondsPerTick);
                         var traceRecord = new LogcatRecord
                         {
                             ProcessId = androidLogEntry.ProcessId,
+                            ProcessName = processName,
                             ThreadId = (int)androidLogEntry.ThreadId,
                             Timestamp = preciseTimestamp.DateTime,
                             Priority = androidLogEntry.Priority,

--- a/src/InstantTraceViewerUI/Logcat/LogcatTraceTableSnapshot.cs
+++ b/src/InstantTraceViewerUI/Logcat/LogcatTraceTableSnapshot.cs
@@ -7,8 +7,6 @@ namespace InstantTraceViewerUI.Logcat
 {
     class LogcatTraceTableSnapshot : ITraceTableSnapshot
     {
-        public IReadOnlyDictionary<int, string> ProcessNames { get; init; }
-
         public ListBuilderSnapshot<LogcatRecord> RecordSnapshot { get; init; }
 
         #region ITraceRecordSnapshot
@@ -26,7 +24,7 @@ namespace InstantTraceViewerUI.Logcat
             {
                 return
                     traceRecord.ProcessId == -1 ? string.Empty :
-                    ProcessNames.TryGetValue(traceRecord.ProcessId, out string name) && !string.IsNullOrEmpty(name) ? $"{traceRecord.ProcessId} ({name})" : traceRecord.ProcessId.ToString();
+                    !string.IsNullOrEmpty(traceRecord.ProcessName) ? $"{traceRecord.ProcessId} ({traceRecord.ProcessName})" : traceRecord.ProcessId.ToString();
             }
             else if (column == LogcatTraceSource.ColumnThread)
             {
@@ -56,7 +54,7 @@ namespace InstantTraceViewerUI.Logcat
             throw new NotImplementedException();
         }
         public string GetColumnValueNameForId(int rowIndex, TraceSourceSchemaColumn column)
-            => column == LogcatTraceSource.ColumnProcess ? (ProcessNames.TryGetValue(RecordSnapshot[rowIndex].ProcessId, out string processName) ? processName : null) :
+            => column == LogcatTraceSource.ColumnProcess ? RecordSnapshot[rowIndex].ProcessName :
                column == LogcatTraceSource.ColumnThread ? null :
                throw new NotSupportedException();
 


### PR DESCRIPTION
Since the OS reuses PIDs pretty frequently, getting the wrong process name was pretty common. To fix this, each trace message will now store the process name as it is known at the time the event is processed.

Fixes #2 