### PR TITLE
Redo logcat/adb support to work around issue with nuget package

### DIFF
--- a/src/Common/Adb/AdbClient.cs
+++ b/src/Common/Adb/AdbClient.cs
@@ -59,7 +59,10 @@ namespace InstantTraceViewer.Adb
             IReadOnlyList<AdbLogId> logIds,
             [EnumeratorCancellation] CancellationToken cancellationToken)
         {
-            using var connection = await OpenDeviceServiceAsync(device, $"shell:{BuildLogcatCommand(logIds)}", cancellationToken);
+            // Use the "exec:" service (raw pipe, no PTY) instead of "shell:" for the binary "-B"
+            // stream. "shell:" merges the command's stderr into stdout and can apply PTY newline
+            // translation, both of which corrupt the binary output.
+            using var connection = await OpenDeviceServiceAsync(device, $"exec:{BuildLogcatCommand(logIds)}", cancellationToken);
             var parser = new AdbLogcatBinaryParser();
 
             while (true)

--- a/src/Common/Adb/AdbClient.cs
+++ b/src/Common/Adb/AdbClient.cs
@@ -1,0 +1,115 @@
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace InstantTraceViewer.Adb
+{
+    public sealed class AdbClient
+    {
+        private const string DefaultHost = "127.0.0.1";
+        private const int DefaultPort = 5037;
+
+        private readonly string _host;
+        private readonly int _port;
+
+        public AdbClient()
+            : this(DefaultHost, DefaultPort)
+        {
+        }
+
+        public AdbClient(string host, int port)
+        {
+            _host = host;
+            _port = port;
+        }
+
+        public async Task<IReadOnlyList<AdbDevice>> GetDevicesAsync(CancellationToken cancellationToken)
+        {
+            using var connection = await AdbProtocolConnection.ConnectAsync(_host, _port, cancellationToken);
+            await connection.SendRequestAsync("host:devices-l", cancellationToken);
+
+            var response = await connection.ReadLengthPrefixedStringAsync(cancellationToken);
+            return AdbDeviceListParser.Parse(response);
+        }
+
+        /// <summary>
+        /// Runs a shell command on the device and returns its combined output.
+        /// The command string is passed verbatim to <c>sh -c</c>; callers are responsible for
+        /// quoting/escaping any user-supplied arguments to prevent shell injection.
+        /// </summary>
+        public async Task<string> ExecuteShellCommandAsync(AdbDevice device, string command, CancellationToken cancellationToken)
+        {
+            using var connection = await OpenDeviceServiceAsync(device, $"shell:{command}", cancellationToken);
+            return await connection.ReadToEndAsync(cancellationToken);
+        }
+
+        public async Task<IReadOnlyList<AdbProcess>> ListProcessesAsync(AdbDevice device, CancellationToken cancellationToken)
+        {
+            var processList = await ExecuteShellCommandAsync(device, "ps -A -o PID,NAME 2>/dev/null || ps", cancellationToken);
+            return AdbProcessParser.Parse(processList);
+        }
+
+        public async Task<IReadOnlyList<AdbPackage>> ListPackagesAsync(AdbDevice device, CancellationToken cancellationToken)
+        {
+            var packageList = await ExecuteShellCommandAsync(device, "pm list packages -U", cancellationToken);
+            return AdbPackageParser.Parse(packageList);
+        }
+
+        public async IAsyncEnumerable<AdbLogEntry> RunLogServiceAsync(
+            AdbDevice device,
+            IReadOnlyList<AdbLogId> logIds,
+            [EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            using var connection = await OpenDeviceServiceAsync(device, $"shell:{BuildLogcatCommand(logIds)}", cancellationToken);
+            var parser = new AdbLogcatBinaryParser();
+
+            while (true)
+            {
+                var entry = await parser.ReadEntryAsync(connection.Stream, cancellationToken);
+                if (entry == null)
+                {
+                    yield break;
+                }
+
+                yield return entry;
+            }
+        }
+
+        private async Task<AdbProtocolConnection> OpenDeviceServiceAsync(AdbDevice device, string service, CancellationToken cancellationToken)
+        {
+            var connection = await AdbProtocolConnection.ConnectAsync(_host, _port, cancellationToken);
+
+            try
+            {
+                await connection.SendRequestAsync($"host:transport:{device.Serial}", cancellationToken);
+                await connection.SendRequestAsync(service, cancellationToken);
+                return connection;
+            }
+            catch
+            {
+                connection.Dispose();
+                throw;
+            }
+        }
+
+        private static string BuildLogcatCommand(IReadOnlyList<AdbLogId> logIds)
+        {
+            var command = new StringBuilder("logcat -B");
+
+            foreach (var logId in logIds.Distinct())
+            {
+                var bufferName = GetLogcatBufferName(logId);
+                if (bufferName != null)
+                {
+                    command.Append(" -b ");
+                    command.Append(bufferName);
+                }
+            }
+
+            return command.ToString();
+        }
+
+        // Buffer names accepted by `logcat -b` happen to be the lowercase enum names.
+        private static string? GetLogcatBufferName(AdbLogId logId)
+            => logId == AdbLogId.Unknown ? null : logId.ToString().ToLowerInvariant();
+    }
+}

--- a/src/Common/Adb/AdbDevice.cs
+++ b/src/Common/Adb/AdbDevice.cs
@@ -1,0 +1,18 @@
+namespace InstantTraceViewer.Adb
+{
+    public sealed class AdbDevice
+    {
+        public required string Serial { get; init; }
+
+        /// <summary>
+        /// The device codename reported by adb (e.g. "emu64x"). Falls back to the model or serial when unavailable.
+        /// </summary>
+        public string Codename { get; init; } = string.Empty;
+
+        public string Model { get; init; } = string.Empty;
+
+        public string Product { get; init; } = string.Empty;
+
+        public string State { get; init; } = string.Empty;
+    }
+}

--- a/src/Common/Adb/AdbDeviceListParser.cs
+++ b/src/Common/Adb/AdbDeviceListParser.cs
@@ -1,0 +1,44 @@
+namespace InstantTraceViewer.Adb
+{
+    public static class AdbDeviceListParser
+    {
+        public static IReadOnlyList<AdbDevice> Parse(string deviceList)
+        {
+            var devices = new List<AdbDevice>();
+
+            foreach (var line in deviceList.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                var parts = line.Split([' ', '\t'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                if (parts.Length < 2)
+                {
+                    continue;
+                }
+
+                var properties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                for (int i = 2; i < parts.Length; i++)
+                {
+                    var separator = parts[i].IndexOf(':');
+                    if (separator > 0)
+                    {
+                        properties[parts[i][..separator]] = parts[i][(separator + 1)..];
+                    }
+                }
+
+                properties.TryGetValue("device", out var codename);
+                properties.TryGetValue("model", out var model);
+                properties.TryGetValue("product", out var product);
+
+                devices.Add(new AdbDevice
+                {
+                    Serial = parts[0],
+                    State = parts[1],
+                    Codename = codename ?? model ?? parts[0],
+                    Model = model ?? string.Empty,
+                    Product = product ?? string.Empty,
+                });
+            }
+
+            return devices;
+        }
+    }
+}

--- a/src/Common/Adb/AdbException.cs
+++ b/src/Common/Adb/AdbException.cs
@@ -1,0 +1,10 @@
+namespace InstantTraceViewer.Adb
+{
+    public sealed class AdbException : Exception
+    {
+        public AdbException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/src/Common/Adb/AdbLogEntry.cs
+++ b/src/Common/Adb/AdbLogEntry.cs
@@ -1,0 +1,24 @@
+namespace InstantTraceViewer.Adb
+{
+    public sealed class AdbLogEntry
+    {
+        public int ProcessId { get; init; }
+
+        public int ThreadId { get; init; }
+
+        // UTC timestamp with sub-second precision. The logcat header's nanosecond field is folded in and rounded to the nearest 100ns tick.
+        public DateTimeOffset TimeStamp { get; init; }
+
+        public AdbLogPriority Priority { get; init; }
+
+        public AdbLogId Id { get; init; }
+
+        // The Linux UID of the process that emitted this log entry, or null if the device
+        // sent a pre-v4 logger header (Android < 7.0) that did not include the UID field.
+        public uint? Uid { get; init; }
+
+        public string Tag { get; init; } = string.Empty;
+
+        public string Message { get; init; } = string.Empty;
+    }
+}

--- a/src/Common/Adb/AdbLogId.cs
+++ b/src/Common/Adb/AdbLogId.cs
@@ -1,0 +1,15 @@
+namespace InstantTraceViewer.Adb
+{
+    public enum AdbLogId
+    {
+        Unknown = -1,
+        Main = 0,
+        Radio = 1,
+        Events = 2,
+        System = 3,
+        Crash = 4,
+        Stats = 5,
+        Security = 6,
+        Kernel = 7,
+    }
+}

--- a/src/Common/Adb/AdbLogPriority.cs
+++ b/src/Common/Adb/AdbLogPriority.cs
@@ -1,0 +1,15 @@
+namespace InstantTraceViewer.Adb
+{
+    public enum AdbLogPriority
+    {
+        Unknown = 0,
+        Default = 1,
+        Verbose = 2,
+        Debug = 3,
+        Info = 4,
+        Warn = 5,
+        Error = 6,
+        Fatal = 7,
+        Silent = 8,
+    }
+}

--- a/src/Common/Adb/AdbLogcatBinaryParser.cs
+++ b/src/Common/Adb/AdbLogcatBinaryParser.cs
@@ -1,0 +1,156 @@
+using System.Buffers.Binary;
+using System.Text;
+
+namespace InstantTraceViewer.Adb
+{
+    public sealed class AdbLogcatBinaryParser
+    {
+        private const int MinimumHeaderSize = 20;
+        private const int MaximumHeaderSize = 512;
+
+        public async ValueTask<AdbLogEntry?> ReadEntryAsync(Stream stream, CancellationToken cancellationToken)
+        {
+            var prefix = new byte[4];
+            if (!await ReadExactOrEndAsync(stream, prefix, cancellationToken))
+            {
+                return null;
+            }
+
+            var payloadLength = BinaryPrimitives.ReadUInt16LittleEndian(prefix.AsSpan(0, 2));
+            var headerSizeOrPadding = BinaryPrimitives.ReadUInt16LittleEndian(prefix.AsSpan(2, 2));
+            var headerSize = headerSizeOrPadding >= MinimumHeaderSize && headerSizeOrPadding <= MaximumHeaderSize ? headerSizeOrPadding : MinimumHeaderSize;
+
+            var header = new byte[headerSize];
+            prefix.CopyTo(header.AsSpan(0, prefix.Length));
+            await ReadExactAsync(stream, header.AsMemory(prefix.Length), cancellationToken);
+
+            var payload = new byte[payloadLength];
+            await ReadExactAsync(stream, payload, cancellationToken);
+
+            return ParseEntry(header, payload);
+        }
+
+        public static AdbLogEntry ParseEntry(ReadOnlySpan<byte> header, ReadOnlySpan<byte> payload)
+        {
+            if (header.Length < MinimumHeaderSize)
+            {
+                throw new InvalidDataException($"Logcat header length {header.Length} is too small.");
+            }
+
+            var processId = BinaryPrimitives.ReadInt32LittleEndian(header[4..8]);
+            var threadId = BinaryPrimitives.ReadInt32LittleEndian(header[8..12]);
+            var seconds = BinaryPrimitives.ReadUInt32LittleEndian(header[12..16]);
+            var nanoSeconds = BinaryPrimitives.ReadInt32LittleEndian(header[16..20]);
+            var logId = AdbLogId.Unknown;
+            uint? uid = null;
+
+            // v2/v3 headers (>= 24 bytes) add the log-id field.
+            if (header.Length >= 24)
+            {
+                var rawLogId = BinaryPrimitives.ReadInt32LittleEndian(header[20..24]);
+                if (Enum.IsDefined(typeof(AdbLogId), rawLogId))
+                {
+                    logId = (AdbLogId)rawLogId;
+                }
+            }
+
+            // v4 headers (>= 28 bytes, Android 7.0+) add the emitting process's UID.
+            if (header.Length >= 28)
+            {
+                uid = BinaryPrimitives.ReadUInt32LittleEndian(header[24..28]);
+            }
+
+            ParsePayload(payload, out var priority, out var tag, out var message);
+
+            var timeStamp = DateTimeOffset.FromUnixTimeSeconds(seconds).AddTicks(nanoSeconds / TimeSpan.NanosecondsPerTick);
+
+            return new AdbLogEntry
+            {
+                ProcessId = processId,
+                ThreadId = threadId,
+                TimeStamp = timeStamp,
+                Priority = priority,
+                Id = logId,
+                Uid = uid,
+                Tag = tag,
+                Message = message,
+            };
+        }
+
+        // Text-format payload layout: [priority][tag]\0[message]\0. Binary event buffers
+        // (Events/Stats and older Security) use a different, typed format and are not decoded here;
+        // requesting those buffers will produce empty or garbled Tag/Message fields.
+        private static void ParsePayload(ReadOnlySpan<byte> payload, out AdbLogPriority priority, out string tag, out string message)
+        {
+            priority = AdbLogPriority.Unknown;
+            tag = string.Empty;
+            message = string.Empty;
+
+            if (payload.Length == 0)
+            {
+                return;
+            }
+
+            priority = ParsePriority(payload[0]);
+
+            var tagStart = 1;
+            var tagLength = payload[tagStart..].IndexOf((byte)0);
+            if (tagLength < 0)
+            {
+                // No null-terminator; payload is not text-formatted (e.g. binary event log).
+                return;
+            }
+
+            var messageStart = tagStart + tagLength + 1;
+            var messageLength = payload[messageStart..].IndexOf((byte)0);
+            if (messageLength < 0)
+            {
+                messageLength = payload.Length - messageStart;
+            }
+
+            tag = Encoding.UTF8.GetString(payload.Slice(tagStart, tagLength));
+            message = Encoding.UTF8.GetString(payload.Slice(messageStart, messageLength));
+        }
+
+        private static AdbLogPriority ParsePriority(byte priority)
+            => priority == 0 ? AdbLogPriority.Unknown :
+               priority == 1 ? AdbLogPriority.Default :
+               priority == 2 ? AdbLogPriority.Verbose :
+               priority == 3 ? AdbLogPriority.Debug :
+               priority == 4 ? AdbLogPriority.Info :
+               priority == 5 ? AdbLogPriority.Warn :
+               priority == 6 ? AdbLogPriority.Error :
+               priority == 7 ? AdbLogPriority.Fatal :
+               priority == 8 ? AdbLogPriority.Silent : AdbLogPriority.Unknown;
+
+        private static async ValueTask<bool> ReadExactOrEndAsync(Stream stream, Memory<byte> buffer, CancellationToken cancellationToken)
+        {
+            var totalBytesRead = 0;
+            while (totalBytesRead < buffer.Length)
+            {
+                var bytesRead = await stream.ReadAsync(buffer[totalBytesRead..], cancellationToken);
+                if (bytesRead == 0)
+                {
+                    if (totalBytesRead == 0)
+                    {
+                        return false;
+                    }
+
+                    throw new EndOfStreamException();
+                }
+
+                totalBytesRead += bytesRead;
+            }
+
+            return true;
+        }
+
+        private static async ValueTask ReadExactAsync(Stream stream, Memory<byte> buffer, CancellationToken cancellationToken)
+        {
+            if (!await ReadExactOrEndAsync(stream, buffer, cancellationToken))
+            {
+                throw new EndOfStreamException();
+            }
+        }
+    }
+}

--- a/src/Common/Adb/AdbPackage.cs
+++ b/src/Common/Adb/AdbPackage.cs
@@ -1,0 +1,9 @@
+namespace InstantTraceViewer.Adb
+{
+    public sealed class AdbPackage
+    {
+        public required string PackageName { get; init; }
+
+        public required uint Uid { get; init; }
+    }
+}

--- a/src/Common/Adb/AdbPackageParser.cs
+++ b/src/Common/Adb/AdbPackageParser.cs
@@ -1,0 +1,53 @@
+namespace InstantTraceViewer.Adb
+{
+    public static class AdbPackageParser
+    {
+        // Parses output of `pm list packages -U`, lines like:
+        //   package:com.example.app uid:10123
+        // Some devices emit trailing whitespace or omit the uid on very old builds; those lines are skipped.
+        public static IReadOnlyList<AdbPackage> Parse(string packageList)
+        {
+            var packages = new List<AdbPackage>();
+
+            foreach (var line in packageList.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                if (!line.StartsWith("package:", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                var parts = line.Split([' ', '\t'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                if (parts.Length < 2)
+                {
+                    continue;
+                }
+
+                var packageName = parts[0]["package:".Length..];
+                if (packageName.Length == 0)
+                {
+                    continue;
+                }
+
+                uint? uid = null;
+                foreach (var part in parts.AsSpan(1))
+                {
+                    if (part.StartsWith("uid:", StringComparison.Ordinal) &&
+                        uint.TryParse(part.AsSpan("uid:".Length), out var parsedUid))
+                    {
+                        uid = parsedUid;
+                        break;
+                    }
+                }
+
+                if (uid == null)
+                {
+                    continue;
+                }
+
+                packages.Add(new AdbPackage { PackageName = packageName, Uid = uid.Value });
+            }
+
+            return packages;
+        }
+    }
+}

--- a/src/Common/Adb/AdbProcess.cs
+++ b/src/Common/Adb/AdbProcess.cs
@@ -1,0 +1,9 @@
+namespace InstantTraceViewer.Adb
+{
+    public sealed class AdbProcess
+    {
+        public required int ProcessId { get; init; }
+
+        public required string Name { get; init; }
+    }
+}

--- a/src/Common/Adb/AdbProcessParser.cs
+++ b/src/Common/Adb/AdbProcessParser.cs
@@ -1,0 +1,60 @@
+namespace InstantTraceViewer.Adb
+{
+    public static class AdbProcessParser
+    {
+        public static IReadOnlyList<AdbProcess> Parse(string processList)
+        {
+            var processes = new List<AdbProcess>();
+            var seenProcessIds = new HashSet<int>();
+
+            foreach (var line in processList.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                var parts = line.Split([' ', '\t'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                if (parts.Length < 2)
+                {
+                    continue;
+                }
+
+                if (TryParseModernPsLine(parts, out var process) || TryParseLegacyPsLine(parts, out process))
+                {
+                    if (seenProcessIds.Add(process!.ProcessId))
+                    {
+                        processes.Add(process);
+                    }
+                }
+            }
+
+            return processes;
+        }
+
+        // Modern layout from `ps -A -o PID,NAME`: exactly two columns.
+        private static bool TryParseModernPsLine(string[] parts, out AdbProcess? process)
+        {
+            process = null;
+
+            if (parts.Length != 2 || !int.TryParse(parts[0], out var processId))
+            {
+                return false;
+            }
+
+            process = new AdbProcess { ProcessId = processId, Name = parts[1] };
+            return true;
+        }
+
+        // Legacy toolbox layout: `USER PID PPID VSIZE RSS WCHAN ADDR S NAME` (9+ columns). Requires
+        // enough columns to distinguish it from the modern two-column layout so we don't accept
+        // arbitrary lines whose second token happens to be numeric.
+        private static bool TryParseLegacyPsLine(string[] parts, out AdbProcess? process)
+        {
+            process = null;
+
+            if (parts.Length < 9 || !int.TryParse(parts[1], out var processId))
+            {
+                return false;
+            }
+
+            process = new AdbProcess { ProcessId = processId, Name = parts[^1] };
+            return true;
+        }
+    }
+}

--- a/src/Common/Adb/AdbProtocolConnection.cs
+++ b/src/Common/Adb/AdbProtocolConnection.cs
@@ -1,0 +1,125 @@
+using System.Globalization;
+using System.Net.Sockets;
+using System.Text;
+
+namespace InstantTraceViewer.Adb
+{
+    internal sealed class AdbProtocolConnection : IDisposable
+    {
+        private readonly TcpClient _client;
+
+        private AdbProtocolConnection(TcpClient client)
+        {
+            _client = client;
+            Stream = client.GetStream();
+        }
+
+        public NetworkStream Stream { get; }
+
+        public static async Task<AdbProtocolConnection> ConnectAsync(string host, int port, CancellationToken cancellationToken)
+        {
+            var client = new TcpClient();
+
+            try
+            {
+                await client.ConnectAsync(host, port, cancellationToken);
+                return new AdbProtocolConnection(client);
+            }
+            catch
+            {
+                client.Dispose();
+                throw;
+            }
+        }
+
+        public async Task SendRequestAsync(string request, CancellationToken cancellationToken)
+        {
+            var requestBytes = Encoding.UTF8.GetBytes(request);
+            var lengthBytes = Encoding.ASCII.GetBytes(requestBytes.Length.ToString("X4", CultureInfo.InvariantCulture));
+
+            await Stream.WriteAsync(lengthBytes, cancellationToken);
+            await Stream.WriteAsync(requestBytes, cancellationToken);
+            await ReadStatusAsync(cancellationToken);
+        }
+
+        public async Task<string> ReadLengthPrefixedStringAsync(CancellationToken cancellationToken)
+        {
+            var responseBytes = await ReadLengthPrefixedBytesAsync(cancellationToken);
+            return Encoding.UTF8.GetString(responseBytes);
+        }
+
+        public async Task<string> ReadToEndAsync(CancellationToken cancellationToken)
+        {
+            using var output = new MemoryStream();
+            var buffer = new byte[8192];
+
+            while (true)
+            {
+                var bytesRead = await Stream.ReadAsync(buffer, cancellationToken);
+                if (bytesRead == 0)
+                {
+                    return Encoding.UTF8.GetString(output.ToArray());
+                }
+
+                output.Write(buffer, 0, bytesRead);
+            }
+        }
+
+        private async Task ReadStatusAsync(CancellationToken cancellationToken)
+        {
+            var statusBytes = new byte[4];
+            await ReadExactAsync(statusBytes, cancellationToken);
+
+            var status = Encoding.ASCII.GetString(statusBytes);
+            if (status == "OKAY")
+            {
+                return;
+            }
+
+            if (status == "FAIL")
+            {
+                var message = await ReadLengthPrefixedStringAsync(cancellationToken);
+                throw new AdbException(message);
+            }
+
+            throw new AdbException($"Unexpected ADB status '{status}'.");
+        }
+
+        private async Task<byte[]> ReadLengthPrefixedBytesAsync(CancellationToken cancellationToken)
+        {
+            var lengthBytes = new byte[4];
+            await ReadExactAsync(lengthBytes, cancellationToken);
+
+            var lengthText = Encoding.ASCII.GetString(lengthBytes);
+            if (!int.TryParse(lengthText, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var length))
+            {
+                throw new AdbException($"Invalid ADB response length '{lengthText}'.");
+            }
+
+            var responseBytes = new byte[length];
+            await ReadExactAsync(responseBytes, cancellationToken);
+            return responseBytes;
+        }
+
+        private async Task ReadExactAsync(Memory<byte> buffer, CancellationToken cancellationToken)
+        {
+            var totalBytesRead = 0;
+            while (totalBytesRead < buffer.Length)
+            {
+                var bytesRead = await Stream.ReadAsync(buffer[totalBytesRead..], cancellationToken);
+                if (bytesRead == 0)
+                {
+                    throw new EndOfStreamException();
+                }
+
+                totalBytesRead += bytesRead;
+            }
+        }
+
+        public void Dispose()
+        {
+            Stream.Dispose();
+            _client.Dispose();
+        }
+    }
+}

--- a/src/Common/ITraceSource.cs
+++ b/src/Common/ITraceSource.cs
@@ -115,6 +115,11 @@
         public TraceSourceSchemaColumn? ThreadIdColumn { get; init; }
 
         /// <summary>
+        /// The column which represents the user id (UID) of a row's originating process. Must support queries using GetColumnValueInt.
+        /// </summary>
+        public TraceSourceSchemaColumn? UidColumn { get; init; }
+
+        /// <summary>
         /// The column which represents the provider/data source of the row.
         /// </summary>
         public TraceSourceSchemaColumn? ProviderColumn { get; init; }
@@ -129,6 +134,24 @@
     {
         public static bool IsValidRowIndex(this ITraceTableSnapshot snapshot, int? rowIndex)
             => rowIndex.HasValue && rowIndex.Value >= 0 && rowIndex.Value < snapshot.RowCount;
+
+        public static int? GetColumnIndex(this TraceTableSchema schema, TraceSourceSchemaColumn? column)
+        {
+            if (column == null)
+            {
+                return null;
+            }
+
+            for (int i = 0; i < schema.Columns.Count; i++)
+            {
+                if (ReferenceEquals(schema.Columns[i], column))
+                {
+                    return i;
+                }
+            }
+
+            return null;
+        }
 
         public static DateTime GetTimestamp(this ITraceTableSnapshot snapshot, int rowIndex)
         {

--- a/src/Common/SyntaxParsers/TraceTableRowSelectorSyntax.cs
+++ b/src/Common/SyntaxParsers/TraceTableRowSelectorSyntax.cs
@@ -287,7 +287,7 @@ namespace InstantTraceViewer
             {
                 return TryParseTimestampPredicate(state, matchedColumn);
             }
-            else if (matchedColumn == _schema.ProcessIdColumn || matchedColumn == _schema.ThreadIdColumn)
+            else if (matchedColumn == _schema.ProcessIdColumn || matchedColumn == _schema.ThreadIdColumn || matchedColumn == _schema.UidColumn)
             {
                 return TryParseMany(state, matchedColumn, TryParseStringPredicate, TryParseIntIdentifierPredicate);
             }

--- a/src/InstantTraceViewerUI/InstantTraceViewerUI.csproj
+++ b/src/InstantTraceViewerUI/InstantTraceViewerUI.csproj
@@ -48,7 +48,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AdvancedSharpAdbClient" Version="3.6.16" />
     <PackageReference Include="Google.Protobuf" Version="3.35.0-rc1" />
     <PackageReference Include="Google.Protobuf.Tools" Version="3.34.1" />
     <PackageReference Include="Hexa.NET.ImGui" Version="2.2.9" />

--- a/src/InstantTraceViewerUI/LogViewerWindow/LogViewerWindow.cs
+++ b/src/InstantTraceViewerUI/LogViewerWindow/LogViewerWindow.cs
@@ -39,6 +39,7 @@ namespace InstantTraceViewerUI
 
         private int? _hoveredProcessId;
         private int? _hoveredThreadId;
+        private int? _hoveredUid;
 
         private ThreadTimelineWindow _threadTimelineWindow = null;
         private FiltersEditorWindow _filtersEditorWindow = null;
@@ -232,6 +233,13 @@ namespace InstantTraceViewerUI
                 _lastSelectedRowYOffset = null;
 
                 int? newHoveredProcessId = null, newHoveredThreadId = null;
+                int? newHoveredUid = null;
+
+                // Resolve the schema column positions once per frame so cell highlighting doesn't depend on any
+                // particular column ordering. null means "column not present in this schema".
+                int? processIdColIndex = visibleTraceTable.Schema.GetColumnIndex(visibleTraceTable.Schema.ProcessIdColumn);
+                int? threadIdColIndex = visibleTraceTable.Schema.GetColumnIndex(visibleTraceTable.Schema.ThreadIdColumn);
+                int? uidColIndex = visibleTraceTable.Schema.GetColumnIndex(visibleTraceTable.Schema.UidColumn);
 
                 _tableClipper.Begin(visibleTraceTable.RowCount);
 
@@ -251,13 +259,17 @@ namespace InstantTraceViewerUI
 
                         float rowYOffset = ImGui.GetCursorPosY();
 
-                        if (visibleTraceTable.Schema.ProcessIdColumn != null && visibleTraceTable.GetProcessId(rowIdx) == _hoveredProcessId)
+                        if (processIdColIndex.HasValue && visibleTraceTable.GetProcessId(rowIdx) == _hoveredProcessId)
                         {
-                            ImGui.TableSetBgColor(ImGuiTableBgTarget.CellBg, AppTheme.MatchingRowBgColor, 0);
+                            ImGui.TableSetBgColor(ImGuiTableBgTarget.CellBg, AppTheme.MatchingRowBgColor, processIdColIndex.Value);
                         }
-                        if (visibleTraceTable.Schema.ThreadIdColumn != null && visibleTraceTable.GetThreadId(rowIdx) == _hoveredThreadId)
+                        if (threadIdColIndex.HasValue && visibleTraceTable.GetThreadId(rowIdx) == _hoveredThreadId)
                         {
-                            ImGui.TableSetBgColor(ImGuiTableBgTarget.CellBg, AppTheme.MatchingRowBgColor, 1);
+                            ImGui.TableSetBgColor(ImGuiTableBgTarget.CellBg, AppTheme.MatchingRowBgColor, threadIdColIndex.Value);
+                        }
+                        if (uidColIndex.HasValue && visibleTraceTable.GetColumnValueInt(rowIdx, visibleTraceTable.Schema.UidColumn) == _hoveredUid)
+                        {
+                            ImGui.TableSetBgColor(ImGuiTableBgTarget.CellBg, AppTheme.MatchingRowBgColor, uidColIndex.Value);
                         }
 
                         HighlightRowBgColor? highlightColor = _viewerRules.TryGetHighlightColor(visibleTraceTable, rowIdx);
@@ -342,13 +354,23 @@ namespace InstantTraceViewerUI
 
                                 if (isRowHovered)
                                 {
-                                    if (visibleTraceTable.Schema.ProcessIdColumn != null && hoveredCol == 0)
+                                    // Resolve which schema column is being hovered by reference rather than by
+                                    // literal column index, so hover-highlighting is independent of column ordering.
+                                    var hoveredColumn = (hoveredCol >= 0 && hoveredCol < visibleTraceTable.Schema.Columns.Count)
+                                        ? visibleTraceTable.Schema.Columns[hoveredCol]
+                                        : null;
+
+                                    if (hoveredColumn != null && hoveredColumn == visibleTraceTable.Schema.ProcessIdColumn)
                                     {
                                         newHoveredProcessId = visibleTraceTable.GetProcessId(rowIdx);
                                     }
-                                    else if (visibleTraceTable.Schema.ThreadIdColumn != null && hoveredCol == 1)
+                                    else if (hoveredColumn != null && hoveredColumn == visibleTraceTable.Schema.ThreadIdColumn)
                                     {
                                         newHoveredThreadId = visibleTraceTable.GetThreadId(rowIdx);
+                                    }
+                                    else if (hoveredColumn != null && hoveredColumn == visibleTraceTable.Schema.UidColumn)
+                                    {
+                                        newHoveredUid = visibleTraceTable.GetColumnValueInt(rowIdx, hoveredColumn);
                                     }
                                 }
 
@@ -442,6 +464,7 @@ namespace InstantTraceViewerUI
 
                 _hoveredProcessId = newHoveredProcessId;
                 _hoveredThreadId = newHoveredThreadId;
+                _hoveredUid = newHoveredUid;
 
                 ImGui.PopStyleVar(); // CellPadding
 
@@ -591,7 +614,7 @@ namespace InstantTraceViewerUI
                 ImGui.Separator();
                 AddCustomRule([TraceTableRowSelectorSyntax.CreateColumnVariableName(column), TraceTableRowSelectorSyntax.LessThanOrEqualOperatorName, timeStr]);
             }
-            else if (column == visibleTraceTable.Schema.ProcessIdColumn || column == visibleTraceTable.Schema.ThreadIdColumn)
+            else if (column == visibleTraceTable.Schema.ProcessIdColumn || column == visibleTraceTable.Schema.ThreadIdColumn || column == visibleTraceTable.Schema.UidColumn)
             {
                 string intValue = visibleTraceTable.GetColumnValueInt(i, column).ToString();
                 string nameValue = visibleTraceTable.GetColumnValueNameForId(i, column);

--- a/src/InstantTraceViewerUI/LogViewerWindow/SpamFilter/CountByUidLevel.cs
+++ b/src/InstantTraceViewerUI/LogViewerWindow/SpamFilter/CountByUidLevel.cs
@@ -1,0 +1,143 @@
+using Hexa.NET.ImGui;
+using InstantTraceViewer;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace InstantTraceViewerUI
+{
+    // Groups events by UID and optionally by unified level. Intended primarily for logcat, but
+    // works for any schema that exposes a UidColumn.
+    internal class CountByUidLevelAdapter : CountByBaseAdapter
+    {
+        private class CountByUidLevel : CountByBase
+        {
+            public int Uid { get; init; }
+            public UnifiedLevel? Level { get; init; }
+
+            // Display-only combined "<uid> (<name>)" string.
+            public string UidDisplayName { get; init; }
+
+            public bool IncludeLevelColumn { get; init; }
+
+            public override void AddColumnValues()
+            {
+                ImGui.TextUnformatted(UidDisplayName);
+                if (IncludeLevelColumn)
+                {
+                    ImGui.TableNextColumn();
+                    ImGui.TextUnformatted(Level?.ToString() ?? "");
+                }
+            }
+        }
+
+        private readonly TraceTableSchema _schema;
+        private readonly bool _includeLevelColumn;
+
+        public CountByUidLevelAdapter(TraceTableSchema schema, bool includeLevelColumn = false)
+        {
+            _schema = schema;
+            _includeLevelColumn = includeLevelColumn;
+        }
+
+        public override string Name => _includeLevelColumn ? $"{UidColumnName}, {LevelColumnName}" : UidColumnName;
+
+        public override int ColumnCount => _includeLevelColumn ? 2 : 1;
+
+        public override void SetupColumns()
+        {
+            ImGui.TableSetupColumn(UidColumnName, ImGuiTableColumnFlags.WidthStretch, 1);
+            if (_includeLevelColumn)
+            {
+                ImGui.TableSetupColumn(LevelColumnName, ImGuiTableColumnFlags.WidthFixed, 8 * ImGui.GetFontSize());
+            }
+        }
+
+        public override IReadOnlyList<CountByBase> CountBy(ITraceTableSnapshot traceTable)
+        {
+            string OptParenthesisIfNeeded(string value) => string.IsNullOrEmpty(value) ? "" : $" ({value})";
+            return
+                Enumerable.Range(0, traceTable.RowCount)
+                    .Select(t =>
+                    {
+                        var uid = traceTable.GetColumnValueInt(t, traceTable.Schema.UidColumn);
+                        var uidName = traceTable.GetColumnValueNameForId(t, traceTable.Schema.UidColumn);
+                        var level = _includeLevelColumn ? traceTable.GetUnifiedLevel(t) : (UnifiedLevel?)null;
+                        return (uid, uidName, level);
+                    })
+                    .GroupBy(t => (t.uid, t.level))
+                    .Select(g => new CountByUidLevel
+                    {
+                        Uid = g.Key.uid,
+                        Level = g.Key.level,
+                        UidDisplayName = g.Key.uid < 0 ? "" : g.Key.uid.ToString() + OptParenthesisIfNeeded(g.Select(v => v.uidName).FirstOrDefault()),
+                        IncludeLevelColumn = _includeLevelColumn,
+                        Count = g.Count(),
+                    })
+                    // Ensure initial default sort is descending so spammy stuff is at the top.
+                    .OrderByDescending(t => t.Count)
+                    .ToList();
+        }
+
+        public override bool IsSchemaSupported()
+            => _schema.UidColumn != null && (!_includeLevelColumn || _schema.UnifiedLevelColumn != null);
+
+        public override IEnumerable<CountByBase> ImGuiSort(ImGuiTableColumnSortSpecsPtr spec, IEnumerable<CountByBase> list)
+        {
+            if (_includeLevelColumn)
+            {
+                return spec.ColumnIndex switch
+                {
+                    0 => ImGuiSortInternal(spec.SortDirection, list, p => ((CountByUidLevel)p).UidDisplayName),
+                    1 => ImGuiSortInternal(spec.SortDirection, list, p => ((CountByUidLevel)p).Level),
+                    2 => ImGuiSortInternal(spec.SortDirection, list, p => ((CountByUidLevel)p).Count),
+                    _ => throw new ArgumentOutOfRangeException(nameof(spec), "Unknown column index"),
+                };
+            }
+
+            return spec.ColumnIndex switch
+            {
+                0 => ImGuiSortInternal(spec.SortDirection, list, p => ((CountByUidLevel)p).UidDisplayName),
+                1 => ImGuiSortInternal(spec.SortDirection, list, p => ((CountByUidLevel)p).Count),
+                _ => throw new ArgumentOutOfRangeException(nameof(spec), "Unknown column index"),
+            };
+        }
+
+        public override void CreateRules(ViewerRules viewerRules, IReadOnlyCollection<CountByBase> countByEventNames, TraceRowRuleAction ruleAction)
+        {
+            var selectedUids = countByEventNames.Cast<CountByUidLevel>()
+                .Where(c => c.Selected)
+                .GroupBy(c => c.Uid)
+                .OrderBy(c => c.Key);
+
+            if (_includeLevelColumn)
+            {
+                // One rule per uid to keep generated rules easy to manage.
+                foreach (var selectedUid in selectedUids)
+                {
+                    var levelStrings = selectedUid.Where(c => c.Level.HasValue).Select(c => c.Level.Value.ToString()).Distinct().ToList();
+                    string query = $"{TraceTableRowSelectorSyntax.CreateColumnVariableName(_schema.UidColumn)} {TraceTableRowSelectorSyntax.EqualsOperatorName} {selectedUid.Key}";
+                    if (levelStrings.Count == 1)
+                    {
+                        query += $" {TraceTableRowSelectorSyntax.AndOperatorName} {TraceTableRowSelectorSyntax.CreateColumnVariableName(_schema.UnifiedLevelColumn)} {TraceTableRowSelectorSyntax.EqualsOperatorName} {levelStrings.Single()}";
+                    }
+                    else if (levelStrings.Count > 1)
+                    {
+                        query += $" {TraceTableRowSelectorSyntax.AndOperatorName} {TraceTableRowSelectorSyntax.CreateColumnVariableName(_schema.UnifiedLevelColumn)} {TraceTableRowSelectorSyntax.InOperatorName} [{string.Join(", ", levelStrings)}]";
+                    }
+                    viewerRules.AddRule(query, ruleAction);
+                }
+            }
+            else
+            {
+                // Single rule listing all selected UIDs.
+                string uidList = string.Join(", ", selectedUids.Select(c => c.Key));
+                string query = $"{TraceTableRowSelectorSyntax.CreateColumnVariableName(_schema.UidColumn)} {TraceTableRowSelectorSyntax.InOperatorName} [{uidList}]";
+                viewerRules.AddRule(query, ruleAction);
+            }
+        }
+
+        private string UidColumnName => _schema.UidColumn?.Name ?? "Uid";
+        private string LevelColumnName => _schema.UnifiedLevelColumn?.Name ?? "Level";
+    }
+}

--- a/src/InstantTraceViewerUI/LogViewerWindow/SpamFilter/SpamFilterWindow.cs
+++ b/src/InstantTraceViewerUI/LogViewerWindow/SpamFilter/SpamFilterWindow.cs
@@ -38,7 +38,9 @@ namespace InstantTraceViewerUI
                     new CountByProviderAdapter(traceTable.Schema),
                     new CountByEventNameAdapter(traceTable.Schema),
                     new CountByProcessThreadAdapter(traceTable.Schema, includeThreadColumn: true),
-                    new CountByProcessThreadAdapter(traceTable.Schema, includeThreadColumn: false)];
+                    new CountByProcessThreadAdapter(traceTable.Schema, includeThreadColumn: false),
+                    new CountByUidLevelAdapter(traceTable.Schema, includeLevelColumn: false),
+                    new CountByUidLevelAdapter(traceTable.Schema, includeLevelColumn: true)];
                 _adaptersLastGenerationId = traceTable.GenerationId;
                 _eventCounts = null;
             }

--- a/src/InstantTraceViewerUI/Logcat/LogcatRecord.cs
+++ b/src/InstantTraceViewerUI/Logcat/LogcatRecord.cs
@@ -1,5 +1,5 @@
-﻿using AdvancedSharpAdbClient.Logs;
-using System;
+﻿using System;
+using InstantTraceViewer.Adb;
 
 namespace InstantTraceViewerUI.Logcat
 {
@@ -11,9 +11,13 @@ namespace InstantTraceViewerUI.Logcat
 
         public int ThreadId;
 
-        public Priority Priority;
+        public uint? Uid;
 
-        public LogId LogId;
+        public string PackageName;
+
+        public AdbLogPriority Priority;
+
+        public AdbLogId LogId;
 
         public string Tag;
 

--- a/src/InstantTraceViewerUI/Logcat/LogcatTraceSource.cs
+++ b/src/InstantTraceViewerUI/Logcat/LogcatTraceSource.cs
@@ -29,6 +29,7 @@ namespace InstantTraceViewerUI.Logcat
             UnifiedLevelColumn = ColumnPriority,
             ProcessIdColumn = ColumnProcess,
             ThreadIdColumn = ColumnThread,
+            UidColumn = ColumnUid,
             ProviderColumn = ColumnBufferId,
             NameColumn = ColumnTag,
         };

--- a/src/InstantTraceViewerUI/Logcat/LogcatTraceSource.cs
+++ b/src/InstantTraceViewerUI/Logcat/LogcatTraceSource.cs
@@ -1,13 +1,13 @@
-using AdvancedSharpAdbClient;
-using AdvancedSharpAdbClient.DeviceCommands;
-using AdvancedSharpAdbClient.Logs;
-using AdvancedSharpAdbClient.Models;
+using InstantTraceViewer;
+using InstantTraceViewer.Adb;
+using InstantTraceViewerUI.Etw;
+using Microsoft.Diagnostics.Tracing;
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text.RegularExpressions;
 using System.Threading;
-using InstantTraceViewer;
 
 namespace InstantTraceViewerUI.Logcat
 {
@@ -15,6 +15,7 @@ namespace InstantTraceViewerUI.Logcat
     {
         public static readonly TraceSourceSchemaColumn ColumnProcess = new TraceSourceSchemaColumn { Name = "Process", DefaultColumnSize = 3.75f };
         public static readonly TraceSourceSchemaColumn ColumnThread = new TraceSourceSchemaColumn { Name = "Thread", DefaultColumnSize = 3.75f };
+        public static readonly TraceSourceSchemaColumn ColumnUid = new TraceSourceSchemaColumn { Name = "Uid", DefaultColumnSize = 8.75f };
         public static readonly TraceSourceSchemaColumn ColumnBufferId = new TraceSourceSchemaColumn { Name = "BufferId", DefaultColumnSize = 3.75f };
         public static readonly TraceSourceSchemaColumn ColumnTag = new TraceSourceSchemaColumn { Name = "Tag", Colorize = true, DefaultColumnSize = 8.75f };
         public static readonly TraceSourceSchemaColumn ColumnPriority = new TraceSourceSchemaColumn { Name = "Priority", DefaultColumnSize = 3.75f };
@@ -23,7 +24,7 @@ namespace InstantTraceViewerUI.Logcat
 
         private static readonly TraceTableSchema _schema = new TraceTableSchema
         {
-            Columns = [ColumnProcess, ColumnThread, ColumnBufferId, ColumnTag, ColumnPriority, ColumnTime, ColumnMessage],
+            Columns = [ColumnProcess, ColumnThread, ColumnUid, ColumnBufferId, ColumnTag, ColumnPriority, ColumnTime, ColumnMessage],
             TimestampColumn = ColumnTime,
             UnifiedLevelColumn = ColumnPriority,
             ProcessIdColumn = ColumnProcess,
@@ -37,26 +38,59 @@ namespace InstantTraceViewerUI.Logcat
         private int _generationId = 0;
         private readonly CancellationTokenSource _tokenSource = new CancellationTokenSource();
         private readonly AdbClient _adbClient;
-        private readonly DeviceData _device;
+        private readonly AdbDevice _device;
         private readonly Thread _readLogcatThread;
 
         private readonly ConcurrentDictionary<int, string> _processNames = new ConcurrentDictionary<int, string>();
+        private readonly ConcurrentDictionary<uint, string> _uidPackageNames = new ConcurrentDictionary<uint, string>();
 
-        public LogcatTraceSource(AdbClient adbClient, DeviceData device)
+        // Well-known Android UIDs (AIDs) from android_filesystem_config.h. These are shared across
+        // many system packages (sharedUserId), so listing every package under them is noise -- we
+        // display the canonical AID name instead. Applies only to UIDs below FIRST_APPLICATION_UID
+        // (10000); user-installed apps always use their package name.
+        internal static readonly IReadOnlyDictionary<uint, string> KnownSystemUidNames = new Dictionary<uint, string>
+        {
+            [0] = "root",
+            [1000] = "system",
+            [1001] = "radio",
+            [1002] = "bluetooth",
+            [1003] = "graphics",
+            [1004] = "input",
+            [1005] = "audio",
+            [1006] = "camera",
+            [1007] = "log",
+            [1009] = "mount",
+            [1010] = "wifi",
+            [1011] = "adb",
+            [1013] = "media",
+            [1014] = "dhcp",
+            [1019] = "drm",
+            [1020] = "mdnsr",
+            [1021] = "gps",
+            [1023] = "media_rw",
+            [1024] = "mtp",
+            [1027] = "nfc",
+            [1036] = "logd",
+            [1041] = "audioserver",
+            [1046] = "mediacodec",
+            [1047] = "cameraserver",
+            [1053] = "webview_zygote",
+            [1058] = "tombstoned",
+            [1066] = "statsd",
+            [1067] = "incidentd",
+            [1069] = "lmkd",
+            [1073] = "network_stack",
+            [2000] = "shell",
+            [9999] = "nobody",
+        };
+
+        public LogcatTraceSource(AdbClient adbClient, AdbDevice device)
         {
             _adbClient = adbClient;
             _device = device;
 
-            // TODO: Package manager can be useful for filtering to 3rd party apps.
-            // -3 to filter to 3rd party
-            // -I to include UID (appended on the 'key' with this API)
-            // var packages = _adbClient.CreatePackageManager(device, "-3", "-U").Packages.OrderBy(p => p.Value).ToList();
-
-            // Start with a snapshot of pids to package names.
-            foreach (var process in _adbClient.ListProcesses(_device))
-            {
-                _processNames.AddOrUpdate(process.ProcessId, _ => process.Name, (_, _) => process.Name);
-            }
+            // Start with a snapshot of pids to process names and uids to package names.
+            RefreshProcessAndPackageNames();
 
             _readLogcatThread = new Thread(() => ReadLogcatThread(adbClient, device));
             _readLogcatThread.Start();
@@ -68,13 +102,10 @@ namespace InstantTraceViewerUI.Logcat
 
         public void Clear()
         {
-            _adbClient.ExecuteShellCommand(_device, "logcat -c");
+            _adbClient.ExecuteShellCommandAsync(_device, "logcat -c", CancellationToken.None).GetAwaiter().GetResult();
 
-            // Refresh the process name map.
-            foreach (var process in _adbClient.ListProcesses(_device))
-            {
-                _processNames.AddOrUpdate(process.ProcessId, _ => process.Name, (_, _) => process.Name);
-            }
+            // Refresh the process and package name maps.
+            RefreshProcessAndPackageNames();
 
             _traceRecordsLock.EnterWriteLock();
             try
@@ -85,6 +116,25 @@ namespace InstantTraceViewerUI.Logcat
             finally
             {
                 _traceRecordsLock.ExitWriteLock();
+            }
+        }
+
+        private void RefreshProcessAndPackageNames()
+        {
+            foreach (var process in _adbClient.ListProcessesAsync(_device, CancellationToken.None).GetAwaiter().GetResult())
+            {
+                _processNames.AddOrUpdate(process.ProcessId, _ => process.Name, (_, _) => process.Name);
+            }
+
+            // `pm list packages -U` groups multiple package names under the same UID when a
+            // sharedUserId is in use (e.g. UID 1000 covers many system packages). Concatenate them
+            // so the UID column still surfaces every mapped name.
+            foreach (var package in _adbClient.ListPackagesAsync(_device, CancellationToken.None).GetAwaiter().GetResult())
+            {
+                _uidPackageNames.AddOrUpdate(
+                    package.Uid,
+                    _ => package.PackageName,
+                    (_, existing) => existing.Contains(package.PackageName) ? existing : $"{existing},{package.PackageName}");
             }
         }
 
@@ -123,50 +173,48 @@ namespace InstantTraceViewerUI.Logcat
             _tokenSource.Cancel();
         }
 
-        private async void ReadLogcatThread(AdbClient adbClient, DeviceData device)
+        private async void ReadLogcatThread(AdbClient adbClient, AdbDevice device)
         {
             try
             {
-                // FIXME: LogId.Kernel can include log entries which break the 'LogService' background processor in AdvancedSharpAdbClient. This causes it to stop reading messages.
-                //        So until this issue is understood and fixed, kernel messages are not included.
-                await foreach (LogEntry logEntry in adbClient.RunLogServiceAsync(device, _tokenSource.Token, [LogId.Main, LogId.Crash, /*LogId.Kernel,*/ LogId.System, LogId.Security, LogId.Radio]))
+                await foreach (AdbLogEntry androidLogEntry in adbClient.RunLogServiceAsync(device, [AdbLogId.Main, AdbLogId.Crash, AdbLogId.System, AdbLogId.Security, AdbLogId.Radio], _tokenSource.Token))
                 {
                     if (IsPaused)
                     {
                         continue;
                     }
 
-                    if (logEntry is AndroidLogEntry androidLogEntry)
+                    ProcessSystemMessage(androidLogEntry);
+
+                    _processNames.TryGetValue(androidLogEntry.ProcessId, out string processName);
+                    string packageName = null;
+                    if (androidLogEntry.Uid.HasValue)
                     {
-                        ProcessSystemMessage(androidLogEntry);
-
-                        _processNames.TryGetValue(androidLogEntry.ProcessId, out string processName);
-                        var preciseTimestamp = androidLogEntry.TimeStamp.ToLocalTime() + TimeSpan.FromTicks(androidLogEntry.NanoSeconds / TimeSpan.NanosecondsPerTick);
-                        var traceRecord = new LogcatRecord
-                        {
-                            ProcessId = androidLogEntry.ProcessId,
-                            ProcessName = processName,
-                            ThreadId = (int)androidLogEntry.ThreadId,
-                            Timestamp = preciseTimestamp.DateTime,
-                            Priority = androidLogEntry.Priority,
-                            Message = androidLogEntry.Message,
-                            Tag = androidLogEntry.Tag,
-                            LogId = androidLogEntry.Id,
-                        };
-
-                        _traceRecordsLock.EnterWriteLock();
-                        try
-                        {
-                            _traceRecords.Add(traceRecord);
-                        }
-                        finally
-                        {
-                            _traceRecordsLock.ExitWriteLock();
-                        }
+                        _uidPackageNames.TryGetValue(androidLogEntry.Uid.Value, out packageName);
                     }
-                    else
+
+                    var traceRecord = new LogcatRecord
                     {
-                        // Sometimes there are pure "LogEntry" objects. Not sure what to do with them...
+                        ProcessId = androidLogEntry.ProcessId,
+                        ProcessName = processName,
+                        ThreadId = androidLogEntry.ThreadId,
+                        Uid = androidLogEntry.Uid,
+                        PackageName = packageName,
+                        Timestamp = androidLogEntry.TimeStamp.ToLocalTime().DateTime,
+                        Priority = androidLogEntry.Priority,
+                        Message = androidLogEntry.Message,
+                        Tag = androidLogEntry.Tag,
+                        LogId = androidLogEntry.Id,
+                    };
+
+                    _traceRecordsLock.EnterWriteLock();
+                    try
+                    {
+                        _traceRecords.Add(traceRecord);
+                    }
+                    finally
+                    {
+                        _traceRecordsLock.ExitWriteLock();
                     }
                 }
             }
@@ -174,11 +222,36 @@ namespace InstantTraceViewerUI.Logcat
             {
                 // Trace source is being disposed.
             }
+            catch (Exception ex)
+            {
+                // This can happen if the ADB server is killed.
+                var traceRecord = new LogcatRecord
+                {
+                    Timestamp = DateTime.Now,
+                    Priority = AdbLogPriority.Fatal,
+                    Message = $"Unexpected error occurred while reading logcat: {ex}",
+                    Tag = "Instant Trace Viewer",
+                    LogId = AdbLogId.Unknown,
+                };
+
+                _traceRecordsLock.EnterWriteLock();
+                try
+                {
+                    _traceRecords.Add(traceRecord);
+                }
+                finally
+                {
+                    _traceRecordsLock.ExitWriteLock();
+                }
+            }
         }
 
-        private static readonly Regex ActivityManagerStartProc = new Regex(@"Start proc (?<pid>\d+).*\{(?<packageName>[^\s/]+)[/].*}");
+        // Matches messages like:
+        //   Start proc 12345:com.example.app/u0a123 for activity {com.example.app/com.example.app.MainActivity}
+        // The uidToken group is optional because very old devices don't include the "<pid>:<procName>/<uidToken>" prefix.
+        private static readonly Regex ActivityManagerStartProc = new Regex(@"Start proc (?<pid>\d+)(?::[^\s/]+/(?<uidToken>\S+))?.*\{(?<packageName>[^\s/]+)[/].*}");
 
-        private void ProcessSystemMessage(AndroidLogEntry androidLogEntry)
+        private void ProcessSystemMessage(AdbLogEntry androidLogEntry)
         {
             if (androidLogEntry.Tag == "ActivityManager")
             {
@@ -187,10 +260,24 @@ namespace InstantTraceViewerUI.Logcat
                     var match = ActivityManagerStartProc.Match(androidLogEntry.Message);
                     if (match.Success)
                     {
+                        var packageName = match.Groups["packageName"].Value;
+
                         _processNames.AddOrUpdate(
                             int.Parse(match.Groups["pid"].Value),
-                            _ => match.Groups["packageName"].Value,
-                            (_, _) => match.Groups["packageName"].Value);
+                            _ => packageName,
+                            (_, _) => packageName);
+
+                        if (match.Groups["uidToken"].Success)
+                        {
+                            var uid = DecodeAndroidUidToken(match.Groups["uidToken"].Value);
+                            if (uid.HasValue)
+                            {
+                                _uidPackageNames.AddOrUpdate(
+                                    uid.Value,
+                                    _ => packageName,
+                                    (_, existing) => existing.Contains(packageName) ? existing : $"{existing},{packageName}");
+                            }
+                        }
                     }
                     else
                     {
@@ -198,6 +285,61 @@ namespace InstantTraceViewerUI.Logcat
                     }
                 }
             }
+        }
+
+        // Decodes Android's UserHandle.formatUid() token into a Linux UID.
+        //   bare integer     -> that integer (system UIDs below FIRST_APPLICATION_UID = 10000)
+        //   u<user>a<n>      -> user*100000 + 10000 + n    (installed app)
+        //   u<user>s<n>      -> user*100000 + n            (shared system UID inside a user profile, n < 10000)
+        //   u<user>i<n>      -> user*100000 + 99000 + n    (isolated process)
+        internal static uint? DecodeAndroidUidToken(string token)
+        {
+            if (string.IsNullOrEmpty(token))
+            {
+                return null;
+            }
+
+            if (uint.TryParse(token, out var bare))
+            {
+                return bare;
+            }
+
+            if (token[0] != 'u' || token.Length < 4)
+            {
+                return null;
+            }
+
+            int userEnd = 1;
+            while (userEnd < token.Length && char.IsDigit(token[userEnd]))
+            {
+                userEnd++;
+            }
+
+            if (userEnd == 1 || userEnd >= token.Length - 1)
+            {
+                return null;
+            }
+
+            if (!uint.TryParse(token.AsSpan(1, userEnd - 1), out var userId))
+            {
+                return null;
+            }
+
+            uint offset;
+            switch (token[userEnd])
+            {
+                case 'a': offset = 10000; break;
+                case 's': offset = 0; break;
+                case 'i': offset = 99000; break;
+                default: return null;
+            }
+
+            if (!uint.TryParse(token.AsSpan(userEnd + 1), out var appId))
+            {
+                return null;
+            }
+
+            return userId * 100000u + offset + appId;
         }
     }
 }

--- a/src/InstantTraceViewerUI/Logcat/LogcatTraceSource.cs
+++ b/src/InstantTraceViewerUI/Logcat/LogcatTraceSource.cs
@@ -248,8 +248,10 @@ namespace InstantTraceViewerUI.Logcat
 
         // Matches messages like:
         //   Start proc 12345:com.example.app/u0a123 for activity {com.example.app/com.example.app.MainActivity}
-        // The uidToken group is optional because very old devices don't include the "<pid>:<procName>/<uidToken>" prefix.
-        private static readonly Regex ActivityManagerStartProc = new Regex(@"Start proc (?<pid>\d+)(?::[^\s/]+/(?<uidToken>\S+))?.*\{(?<packageName>[^\s/]+)[/].*}");
+        // procName and uidToken come from the "<pid>:<procName>/<uidToken>" prefix (Android 8+); they are
+        // optional so pre-8 formats still match, in which case procName falls back to packageName below.
+        // procName can differ from packageName when an app declares a process suffix, e.g. "com.example.app:remoteworker".
+        private static readonly Regex ActivityManagerStartProc = new Regex(@"Start proc (?<pid>\d+)(?::(?<procName>[^\s/]+)/(?<uidToken>\S+))?.*\{(?<packageName>[^\s/]+)[/].*}");
 
         private void ProcessSystemMessage(AdbLogEntry androidLogEntry)
         {
@@ -261,11 +263,12 @@ namespace InstantTraceViewerUI.Logcat
                     if (match.Success)
                     {
                         var packageName = match.Groups["packageName"].Value;
+                        var procName = match.Groups["procName"].Success ? match.Groups["procName"].Value : packageName;
 
                         _processNames.AddOrUpdate(
                             int.Parse(match.Groups["pid"].Value),
-                            _ => packageName,
-                            (_, _) => packageName);
+                            _ => procName,
+                            (_, _) => procName);
 
                         if (match.Groups["uidToken"].Success)
                         {

--- a/src/InstantTraceViewerUI/Logcat/LogcatTraceSource.cs
+++ b/src/InstantTraceViewerUI/Logcat/LogcatTraceSource.cs
@@ -127,17 +127,21 @@ namespace InstantTraceViewerUI.Logcat
                 _processNames.AddOrUpdate(process.ProcessId, _ => process.Name, (_, _) => process.Name);
             }
 
-            // `pm list packages -U` groups multiple package names under the same UID when a
-            // sharedUserId is in use (e.g. UID 1000 covers many system packages). Concatenate them
-            // so the UID column still surfaces every mapped name.
+            // `pm list packages -U` groups multiple package names under the same UID when a sharedUserId is in use
+            // (e.g. UID 1000 covers many system packages). Concatenate them so the UID column still surfaces every mapped name.
             foreach (var package in _adbClient.ListPackagesAsync(_device, CancellationToken.None).GetAwaiter().GetResult())
             {
                 _uidPackageNames.AddOrUpdate(
                     package.Uid,
                     _ => package.PackageName,
-                    (_, existing) => existing.Contains(package.PackageName) ? existing : $"{existing},{package.PackageName}");
+                    (_, existing) => ContainsPackageToken(existing, package.PackageName) ? existing : $"{existing},{package.PackageName}");
             }
         }
+
+        // Returns true if commaJoinedPackages already lists candidate as a comma-separated token. Wrapping both strings in commas
+        // avoids substring false positives (e.g. "com.example" being considered "contained in" "com.example.foo").
+        private static bool ContainsPackageToken(string commaJoinedPackages, string candidate)
+            => $",{commaJoinedPackages},".Contains($",{candidate},", StringComparison.Ordinal);
 
         public bool CanPause => true;
         public bool IsPaused { get; private set; }
@@ -279,7 +283,7 @@ namespace InstantTraceViewerUI.Logcat
                                 _uidPackageNames.AddOrUpdate(
                                     uid.Value,
                                     _ => packageName,
-                                    (_, existing) => existing.Contains(packageName) ? existing : $"{existing},{packageName}");
+                                    (_, existing) => ContainsPackageToken(existing, packageName) ? existing : $"{existing},{packageName}");
                             }
                         }
                     }

--- a/src/InstantTraceViewerUI/Logcat/LogcatTraceTableSnapshot.cs
+++ b/src/InstantTraceViewerUI/Logcat/LogcatTraceTableSnapshot.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-using AdvancedSharpAdbClient.Logs;
 using InstantTraceViewer;
+using InstantTraceViewer.Adb;
 
 namespace InstantTraceViewerUI.Logcat
 {
@@ -28,6 +28,24 @@ namespace InstantTraceViewerUI.Logcat
             else if (column == LogcatTraceSource.ColumnThread)
             {
                 return traceRecord.ThreadId.ToString();
+            }
+            else if (column == LogcatTraceSource.ColumnUid)
+            {
+                if (!traceRecord.Uid.HasValue)
+                {
+                    return string.Empty;
+                }
+
+                // Prefer the canonical Android AID name for well-known system UIDs; those UIDs are
+                // shared by many packages and the joined package list would be huge and unhelpful.
+                if (LogcatTraceSource.KnownSystemUidNames.TryGetValue(traceRecord.Uid.Value, out var aidName))
+                {
+                    return $"{traceRecord.Uid.Value} ({aidName})";
+                }
+
+                return !string.IsNullOrEmpty(traceRecord.PackageName)
+                    ? $"{traceRecord.Uid.Value} ({traceRecord.PackageName})"
+                    : traceRecord.Uid.Value.ToString();
             }
             else if (column == LogcatTraceSource.ColumnPriority)
             {
@@ -74,13 +92,12 @@ namespace InstantTraceViewerUI.Logcat
         public UnifiedOpcode GetColumnValueUnifiedOpcode(int rowIndex, TraceSourceSchemaColumn column)
             => throw new NotSupportedException();
 
-        private UnifiedLevel ConvertPriority(Priority priority)
-            => priority == Priority.Fatal ? UnifiedLevel.Fatal :
-               priority == Priority.Error ? UnifiedLevel.Error :
-               priority == Priority.Assert ? UnifiedLevel.Error :
-               priority == Priority.Warn ? UnifiedLevel.Warning :
-               priority == Priority.Verbose ? UnifiedLevel.Verbose :
-               priority == Priority.Debug ? UnifiedLevel.Verbose : UnifiedLevel.Info;
+        private UnifiedLevel ConvertPriority(AdbLogPriority priority)
+            => priority == AdbLogPriority.Fatal ? UnifiedLevel.Fatal :
+               priority == AdbLogPriority.Error ? UnifiedLevel.Error :
+               priority == AdbLogPriority.Warn ? UnifiedLevel.Warning :
+               priority == AdbLogPriority.Verbose ? UnifiedLevel.Verbose :
+               priority == AdbLogPriority.Debug ? UnifiedLevel.Verbose : UnifiedLevel.Info;
         #endregion
     }
 }

--- a/src/InstantTraceViewerUI/Logcat/LogcatTraceTableSnapshot.cs
+++ b/src/InstantTraceViewerUI/Logcat/LogcatTraceTableSnapshot.cs
@@ -70,11 +70,28 @@ namespace InstantTraceViewerUI.Logcat
 
             throw new NotImplementedException();
         }
-        public string GetColumnValueNameForId(int rowIndex, TraceSourceSchemaColumn column)
-            => column == LogcatTraceSource.ColumnProcess ? RecordSnapshot[rowIndex].ProcessName :
-               column == LogcatTraceSource.ColumnThread ? null :
-               throw new NotSupportedException();
 
+        public string GetColumnValueNameForId(int rowIndex, TraceSourceSchemaColumn column)
+        {
+            if (column == LogcatTraceSource.ColumnProcess)
+            {
+                return RecordSnapshot[rowIndex].ProcessName;
+            }
+            if (column == LogcatTraceSource.ColumnThread)
+            {
+                return null;
+            }
+            if (column == LogcatTraceSource.ColumnUid)
+            {
+                var record = RecordSnapshot[rowIndex];
+                if (!record.Uid.HasValue)
+                {
+                    return null;
+                }
+                return LogcatTraceSource.KnownSystemUidNames.TryGetValue(record.Uid.Value, out var aidName) ? aidName : record.PackageName;
+            }
+            throw new NotSupportedException();
+        }
 
         public DateTime GetColumnValueDateTime(int rowIndex, TraceSourceSchemaColumn column)
             => column == LogcatTraceSource.ColumnTime ? RecordSnapshot[rowIndex].Timestamp :
@@ -83,6 +100,7 @@ namespace InstantTraceViewerUI.Logcat
         public int GetColumnValueInt(int rowIndex, TraceSourceSchemaColumn column)
             => column == LogcatTraceSource.ColumnProcess ? RecordSnapshot[rowIndex].ProcessId :
                column == LogcatTraceSource.ColumnThread ? RecordSnapshot[rowIndex].ThreadId :
+               column == LogcatTraceSource.ColumnUid ? (RecordSnapshot[rowIndex].Uid.HasValue ? (int)RecordSnapshot[rowIndex].Uid.Value : -1) :
                throw new NotSupportedException();
 
         public UnifiedLevel GetColumnValueUnifiedLevel(int rowIndex, TraceSourceSchemaColumn column)

--- a/src/InstantTraceViewerUI/MainWindow.cs
+++ b/src/InstantTraceViewerUI/MainWindow.cs
@@ -5,10 +5,11 @@ using System.IO;
 using System.Linq;
 using System.Net.Sockets;
 using System.Numerics;
-using AdvancedSharpAdbClient;
-using AdvancedSharpAdbClient.Models;
+using System.Threading;
+using System.Threading.Tasks;
 using Hexa.NET.ImGui;
 using InstantTraceViewer;
+using InstantTraceViewer.Adb;
 using Windows.Win32;
 using Windows.Win32.Foundation;
 
@@ -25,7 +26,8 @@ namespace InstantTraceViewerUI
         }
 
         private readonly AdbClient _adbClient = new AdbClient();
-        private IReadOnlyList<DeviceData> _adbDevices = null;
+        private Task<IReadOnlyList<AdbDevice>> _adbDevicesTask = null;
+        private IReadOnlyList<AdbDevice> _adbDevices = null;
         private Exception _adbDevicesException = null;
 
         record class MessageBoxData(string Message, string Title, bool IsError);
@@ -445,14 +447,23 @@ namespace InstantTraceViewerUI
                 {
                     if (_adbDevices == null && _adbDevicesException == null)
                     {
-                        try
+                        _adbDevicesTask ??= _adbClient.GetDevicesAsync(CancellationToken.None);
+
+                        if (_adbDevicesTask.IsCompleted)
                         {
-                            _adbDevices = _adbClient.GetDevices().ToList();
-                        }
-                        catch (SocketException ex)
-                        {
-                            _adbDevicesException = ex;
-                            _adbDevices = Array.Empty<DeviceData>();
+                            try
+                            {
+                                _adbDevices = _adbDevicesTask.GetAwaiter().GetResult();
+                            }
+                            catch (SocketException ex)
+                            {
+                                _adbDevicesException = ex;
+                                _adbDevices = Array.Empty<AdbDevice>();
+                            }
+                            finally
+                            {
+                                _adbDevicesTask = null;
+                            }
                         }
                     }
 
@@ -461,14 +472,18 @@ namespace InstantTraceViewerUI
                         // TODO: See if adb.exe is in the PATH and offer to start the server.
                         ImGui.TextUnformatted("ADB server not running");
                     }
+                    else if (_adbDevices == null)
+                    {
+                        ImGui.TextUnformatted("Connecting...");
+                    }
                     else if (_adbDevices.Count == 0)
                     {
                         ImGui.TextUnformatted("No devices found");
                     }
 
-                    foreach (var device in _adbDevices)
+                    foreach (var device in _adbDevices ?? Array.Empty<AdbDevice>())
                     {
-                        if (ImGui.BeginMenu($"{device.Name} {device.Model} {device.Serial}"))
+                        if (ImGui.BeginMenu($"{device.Codename} {device.Model} {device.Serial}"))
                         {
                             if (ImGui.MenuItem("Open logcat"))
                             {
@@ -483,6 +498,7 @@ namespace InstantTraceViewerUI
 
                     if (ImGui.MenuItem("Refresh devices"))
                     {
+                        _adbDevicesTask = null;
                         _adbDevices = null;
                         _adbDevicesException = null;
                     }

--- a/src/InstantTraceViewerUI/MainWindow.cs
+++ b/src/InstantTraceViewerUI/MainWindow.cs
@@ -455,7 +455,7 @@ namespace InstantTraceViewerUI
                             {
                                 _adbDevices = _adbDevicesTask.GetAwaiter().GetResult();
                             }
-                            catch (SocketException ex)
+                            catch (Exception ex) when (ex is SocketException or IOException or AdbException)
                             {
                                 _adbDevicesException = ex;
                                 _adbDevices = Array.Empty<AdbDevice>();
@@ -470,7 +470,7 @@ namespace InstantTraceViewerUI
                     if (_adbDevicesException != null)
                     {
                         // TODO: See if adb.exe is in the PATH and offer to start the server.
-                        ImGui.TextUnformatted("ADB server not running");
+                        ImGui.TextUnformatted($"ADB error: {_adbDevicesException.Message}");
                     }
                     else if (_adbDevices == null)
                     {

--- a/src/UnitTests/AdbTests.cs
+++ b/src/UnitTests/AdbTests.cs
@@ -1,0 +1,138 @@
+using System.Buffers.Binary;
+using System.Text;
+using InstantTraceViewer.Adb;
+
+namespace InstantTraceViewerTests
+{
+    [TestClass]
+    public class AdbTests
+    {
+        [TestMethod]
+        public void ParseDeviceList()
+        {
+            var devices = AdbDeviceListParser.Parse("emulator-5554\tdevice product:sdk_gphone64_x86_64 model:sdk_gphone64_x86_64 device:emu64x vendor:Google\r\n");
+
+            Assert.AreEqual(1, devices.Count);
+            Assert.AreEqual("emulator-5554", devices[0].Serial);
+            Assert.AreEqual("device", devices[0].State);
+            Assert.AreEqual("emu64x", devices[0].Codename);
+            Assert.AreEqual("sdk_gphone64_x86_64", devices[0].Model);
+            Assert.AreEqual("sdk_gphone64_x86_64", devices[0].Product);
+        }
+
+        [TestMethod]
+        public void ParseModernProcessList()
+        {
+            var processes = AdbProcessParser.Parse("PID NAME\n1 init\n1234 com.example.app\n");
+
+            Assert.AreEqual(2, processes.Count);
+            Assert.AreEqual(1, processes[0].ProcessId);
+            Assert.AreEqual("init", processes[0].Name);
+            Assert.AreEqual(1234, processes[1].ProcessId);
+            Assert.AreEqual("com.example.app", processes[1].Name);
+        }
+
+        [TestMethod]
+        public void ParseLegacyProcessList()
+        {
+            var processes = AdbProcessParser.Parse("USER PID PPID VSIZE RSS WCHAN ADDR S NAME\nshell 345 1 123 456 0 0 S logcat\n");
+
+            Assert.AreEqual(1, processes.Count);
+            Assert.AreEqual(345, processes[0].ProcessId);
+            Assert.AreEqual("logcat", processes[0].Name);
+        }
+
+        [TestMethod]
+        public void ParsePackageList()
+        {
+            var packages = AdbPackageParser.Parse(
+                "package:com.android.chrome uid:10123\r\n" +
+                "package:com.google.android.gms uid:10012\r\n" +
+                "package:com.google.android.gsf uid:10012\r\n" +
+                "package:android uid:1000\r\n");
+
+            Assert.AreEqual(4, packages.Count);
+            Assert.AreEqual("com.android.chrome", packages[0].PackageName);
+            Assert.AreEqual((uint)10123, packages[0].Uid);
+            Assert.AreEqual("com.google.android.gms", packages[1].PackageName);
+            Assert.AreEqual((uint)10012, packages[1].Uid);
+            Assert.AreEqual("com.google.android.gsf", packages[2].PackageName);
+            Assert.AreEqual((uint)10012, packages[2].Uid);
+            Assert.AreEqual("android", packages[3].PackageName);
+            Assert.AreEqual((uint)1000, packages[3].Uid);
+        }
+
+        [TestMethod]
+        public void ParsePackageList_SkipsMalformedLines()
+        {
+            var packages = AdbPackageParser.Parse(
+                "package:com.example uid:10001\n" +
+                "package:no.uid.here\n" +               // no uid field
+                "package: uid:12345\n" +                 // empty package name
+                "not-a-package-line\n" +
+                "package:another uid:notanumber\n" +    // non-numeric uid
+                "package:okay uid:10002\n");
+
+            Assert.AreEqual(2, packages.Count);
+            Assert.AreEqual("com.example", packages[0].PackageName);
+            Assert.AreEqual((uint)10001, packages[0].Uid);
+            Assert.AreEqual("okay", packages[1].PackageName);
+            Assert.AreEqual((uint)10002, packages[1].Uid);
+        }
+
+        [TestMethod]
+        public void ParseBinaryLogcatEntry()
+        {
+            var payload = new byte[1 + "ActivityManager".Length + 1 + "Start proc 1234:com.example/u0a123 for activity".Length + 1];
+            payload[0] = 4;
+            Encoding.UTF8.GetBytes("ActivityManager").CopyTo(payload, 1);
+            Encoding.UTF8.GetBytes("Start proc 1234:com.example/u0a123 for activity").CopyTo(payload, 1 + "ActivityManager".Length + 1);
+
+            var header = new byte[24];
+            BinaryPrimitives.WriteUInt16LittleEndian(header.AsSpan(0, 2), (ushort)payload.Length);
+            BinaryPrimitives.WriteUInt16LittleEndian(header.AsSpan(2, 2), (ushort)header.Length);
+            BinaryPrimitives.WriteInt32LittleEndian(header.AsSpan(4, 4), 4321);
+            BinaryPrimitives.WriteInt32LittleEndian(header.AsSpan(8, 4), 5678);
+            BinaryPrimitives.WriteUInt32LittleEndian(header.AsSpan(12, 4), 946684800);
+            BinaryPrimitives.WriteInt32LittleEndian(header.AsSpan(16, 4), 123456789);
+            BinaryPrimitives.WriteInt32LittleEndian(header.AsSpan(20, 4), (int)AdbLogId.System);
+
+            var entry = AdbLogcatBinaryParser.ParseEntry(header, payload);
+
+            Assert.AreEqual(4321, entry.ProcessId);
+            Assert.AreEqual(5678, entry.ThreadId);
+            Assert.AreEqual(DateTimeOffset.FromUnixTimeSeconds(946684800).AddTicks(123456789 / TimeSpan.NanosecondsPerTick), entry.TimeStamp);
+            Assert.AreEqual(AdbLogPriority.Info, entry.Priority);
+            Assert.AreEqual(AdbLogId.System, entry.Id);
+            Assert.IsNull(entry.Uid, "v3 headers do not carry a UID field.");
+            Assert.AreEqual("ActivityManager", entry.Tag);
+            Assert.AreEqual("Start proc 1234:com.example/u0a123 for activity", entry.Message);
+        }
+
+        [TestMethod]
+        public void ParseBinaryLogcatEntryWithUid()
+        {
+            var payload = new byte[1 + "MyTag".Length + 1 + "hello".Length + 1];
+            payload[0] = 4;
+            Encoding.UTF8.GetBytes("MyTag").CopyTo(payload, 1);
+            Encoding.UTF8.GetBytes("hello").CopyTo(payload, 1 + "MyTag".Length + 1);
+
+            // v4 header: 28 bytes, includes uid at offset 24.
+            var header = new byte[28];
+            BinaryPrimitives.WriteUInt16LittleEndian(header.AsSpan(0, 2), (ushort)payload.Length);
+            BinaryPrimitives.WriteUInt16LittleEndian(header.AsSpan(2, 2), (ushort)header.Length);
+            BinaryPrimitives.WriteInt32LittleEndian(header.AsSpan(4, 4), 1000);
+            BinaryPrimitives.WriteInt32LittleEndian(header.AsSpan(8, 4), 1000);
+            BinaryPrimitives.WriteUInt32LittleEndian(header.AsSpan(12, 4), 946684800);
+            BinaryPrimitives.WriteInt32LittleEndian(header.AsSpan(16, 4), 0);
+            BinaryPrimitives.WriteInt32LittleEndian(header.AsSpan(20, 4), (int)AdbLogId.Main);
+            BinaryPrimitives.WriteUInt32LittleEndian(header.AsSpan(24, 4), 10123);
+
+            var entry = AdbLogcatBinaryParser.ParseEntry(header, payload);
+
+            Assert.AreEqual((uint?)10123, entry.Uid);
+            Assert.AreEqual("MyTag", entry.Tag);
+            Assert.AreEqual("hello", entry.Message);
+        }
+    }
+}


### PR DESCRIPTION
AdvancedSharpAdbClient can be put into a broken state when reading some unknown logcat data. This moves to using our own ADB client which was written mostly by Claude/GPT. This also includes some improvements:
* UID column with package name
* Spam filter options for UID
* No more hanging when opening the Android menu for the first time. Devices refresh in the background.

Fixes #10